### PR TITLE
BAU - Update saml libs to use new verify-saml-libs repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,21 +36,20 @@ repositories {
     maven { url 'https://artifactory.ida.digital.cabinet-office.gov.uk/artifactory/whitelisted-repos/' }
 }
 
+ext {
+    opensaml = '3.3.0'
+}
+
 def dependencyVersions = [
         ida_utils:317,
         dropwizard:'1.2.0',
         dropwizard_jade:10511,
         ida_test_utils: '2.0.0-38',
         ida_dev_pki: '1.1.0-20',
-        saml_serializers: '3.3.0-26',
-        saml_security: '3.3.0-49',
-        opensaml_version: '3.3.0',
-        saml_metadata_bindings: '3.3.0-73',
-        hub_saml: '3.3.0-93',
-        saml_extensions: '3.3.0-1.2a-36',
-        stub_idp_saml: '3.3.0-58',
-        saml_domain_objects: '3.3.0-37',
-        saml_test_utils: '3.3.0-31',
+        opensaml_version: "$opensaml",
+        saml_libs_version: "$opensaml-109",
+        hub_saml: '3.3.0-123',
+        stub_idp_saml: '3.3.0-68'
 ]
 
 configurations {
@@ -108,18 +107,15 @@ dependencies {
 
     saml "org.opensaml:opensaml-core:$dependencyVersions.opensaml_version",
             "org.opensaml:opensaml-saml-impl:$dependencyVersions.opensaml_version",
-            "uk.gov.ida:ida-saml-extensions:$dependencyVersions.saml_extensions",
-            "uk.gov.ida:saml-serializers:$dependencyVersions.saml_serializers",
-            "uk.gov.ida:saml-security:$dependencyVersions.saml_security",
-            "uk.gov.ida:saml-metadata-bindings:$dependencyVersions.saml_metadata_bindings",
+            "uk.gov.ida:saml-extensions:$dependencyVersions.saml_libs_version",
+            "uk.gov.ida:saml-serializers:$dependencyVersions.saml_libs_version",
+            "uk.gov.ida:saml-security:$dependencyVersions.saml_libs_version",
+            "uk.gov.ida:saml-metadata-bindings:$dependencyVersions.saml_libs_version",
             "uk.gov.ida:stub-idp-saml:$dependencyVersions.stub_idp_saml",
             "uk.gov.ida:hub-saml:$dependencyVersions.hub_saml",
-            "uk.gov.ida:hub-saml-test-utils:$dependencyVersions.hub_saml",
-            "uk.gov.verify:saml-domain-objects:$dependencyVersions.saml_domain_objects",
-            "uk.gov.verify:saml-test-utils:$dependencyVersions.saml_test_utils"
+            "uk.gov.ida:hub-saml-test-utils:$dependencyVersions.hub_saml"
 
-    saml_test "uk.gov.ida:ida-saml-extensions-test:$dependencyVersions.saml_extensions",
-            "uk.gov.ida:saml-metadata-bindings-test:$dependencyVersions.saml_metadata_bindings",
+    saml_test "uk.gov.ida:saml-metadata-bindings-test:$dependencyVersions.saml_libs_version",
 
             soap('org.apache.ws.commons:ws-commons-util:1.0.1') { transitive = false }
 

--- a/src/integration-test/java/uk/gov/ida/integrationTest/support/TestRpAppRule.java
+++ b/src/integration-test/java/uk/gov/ida/integrationTest/support/TestRpAppRule.java
@@ -2,8 +2,6 @@ package uk.gov.ida.integrationTest.support;
 
 import com.google.common.collect.ImmutableList;
 import com.squarespace.jersey2.guice.JerseyGuiceUtils;
-import helpers.ManagedFileResource;
-import helpers.TemporaryFileResource;
 import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit.DropwizardAppRule;
@@ -12,63 +10,39 @@ import uk.gov.ida.saml.core.test.TestCertificateStrings;
 
 import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
-import java.util.List;
-
-import static helpers.TemporaryFileResourceBuilder.aTemporaryFileResource;
-import static java.util.Arrays.asList;
-import static org.apache.commons.codec.binary.Base64.decodeBase64;
 
 public class TestRpAppRule extends DropwizardAppRule<TestRpConfiguration> {
-    private final List<ManagedFileResource> managedFileResources;
 
-    private TestRpAppRule(final List<ManagedFileResource> managedFileResources, final ConfigOverride[] configOverrides) {
+    private TestRpAppRule(final ConfigOverride[] configOverrides) {
         super(TestRpIntegrationApplication.class, ResourceHelpers.resourceFilePath("test-rp.yml"), configOverrides);
-        this.managedFileResources = managedFileResources;
     }
 
     public static TestRpAppRule newTestRpAppRule(final ConfigOverride... configOverrides) {
-        TemporaryFileResource privateSigningKey = aTemporaryFileResource()
-                .content(decodeBase64(TestCertificateStrings.TEST_RP_PRIVATE_SIGNING_KEY))
-                .build();
-        TemporaryFileResource publicSigningCert = aTemporaryFileResource()
-                .content(TestCertificateStrings.TEST_RP_PUBLIC_SIGNING_CERT)
-                .build();
-        TemporaryFileResource privateEncryptionKey = aTemporaryFileResource()
-                .content(decodeBase64(TestCertificateStrings.TEST_RP_PRIVATE_ENCRYPTION_KEY))
-                .build();
-        TemporaryFileResource publicEncryptionCert = aTemporaryFileResource()
-                .content(TestCertificateStrings.TEST_RP_PUBLIC_ENCRYPTION_CERT)
-                .build();
-
-        List<ManagedFileResource> managedFileResources = asList(
-                privateSigningKey,
-                publicSigningCert,
-                privateEncryptionKey,
-                publicEncryptionCert
-        );
 
         ImmutableList<ConfigOverride> mergedConfigOverrides = ImmutableList.<ConfigOverride>builder()
-                .add(ConfigOverride.config("privateSigningKeyConfiguration.keyFile", privateSigningKey.getPath()))
-                .add(ConfigOverride.config("publicSigningCert.certFile", publicSigningCert.getPath() ))
-                .add(ConfigOverride.config("privateEncryptionKeyConfiguration.keyFile", privateEncryptionKey.getPath()))
-                .add(ConfigOverride.config("publicEncryptionCert.certFile", publicEncryptionCert.getPath()))
+                .add(ConfigOverride.config("privateSigningKeyConfiguration.key", TestCertificateStrings.TEST_RP_PRIVATE_SIGNING_KEY))
+                .add(ConfigOverride.config("privateSigningKeyConfiguration.type", "encoded"))
+                .add(ConfigOverride.config("publicSigningCert.cert", TestCertificateStrings.TEST_RP_PUBLIC_SIGNING_CERT))
+                .add(ConfigOverride.config("publicSigningCert.type", "x509"))
+                .add(ConfigOverride.config("privateEncryptionKeyConfiguration.key", TestCertificateStrings.TEST_RP_PRIVATE_ENCRYPTION_KEY))
+                .add(ConfigOverride.config("privateEncryptionKeyConfiguration.type", "encoded"))
+                .add(ConfigOverride.config("publicEncryptionCert.cert", TestCertificateStrings.TEST_RP_PUBLIC_ENCRYPTION_CERT))
+                .add(ConfigOverride.config("publicEncryptionCert.type", "x509"))
                 .add(configOverrides)
                 .build();
 
         JerseyGuiceUtils.reset();
         ConfigOverride[] configOverridesArray = mergedConfigOverrides.toArray(new ConfigOverride[mergedConfigOverrides.size()]);
-        return new TestRpAppRule(managedFileResources, configOverridesArray);
+        return new TestRpAppRule(configOverridesArray);
     }
 
     @Override
     protected void before() {
-        managedFileResources.forEach(ManagedFileResource::create);
         super.before();
     }
 
     @Override
     protected void after() {
-        managedFileResources.forEach(ManagedFileResource::delete);
         super.after();
     }
 

--- a/src/main/java/uk/gov/ida/rp/testrp/controllogic/AuthnResponseReceiverHandler.java
+++ b/src/main/java/uk/gov/ida/rp/testrp/controllogic/AuthnResponseReceiverHandler.java
@@ -52,11 +52,11 @@ public class AuthnResponseReceiverHandler {
             if (idpResponse.getAttributes().isPresent()) {
                 // display real attributes contined within the saml response
                 List<String> attributes = getAttributes(idpResponse);
-                return new ResponseFromHub(idpResponse.getStatus(), attributes, Optional.empty(), Optional.ofNullable(session), relayState, idpResponse.getAuthnContext().toJavaUtil());
+                return new ResponseFromHub(idpResponse.getStatus(), attributes, Optional.empty(), Optional.ofNullable(session), relayState, idpResponse.getAuthnContext());
             }
 
             URI location = session.getPathUserWasTryingToAccess();
-            return new ResponseFromHub(idpResponse.getStatus(), ImmutableList.of(), Optional.ofNullable(location), Optional.ofNullable(session), relayState, idpResponse.getAuthnContext().toJavaUtil());
+            return new ResponseFromHub(idpResponse.getStatus(), ImmutableList.of(), Optional.ofNullable(location), Optional.ofNullable(session), relayState, idpResponse.getAuthnContext());
         }
         // not success, not a new user, no relay state
         return new ResponseFromHub(idpResponse.getStatus(), ImmutableList.of(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());

--- a/src/main/java/uk/gov/ida/rp/testrp/saml/transformers/InboundResponseFromHubUnmarshaller.java
+++ b/src/main/java/uk/gov/ida/rp/testrp/saml/transformers/InboundResponseFromHubUnmarshaller.java
@@ -1,6 +1,5 @@
 package uk.gov.ida.rp.testrp.saml.transformers;
 
-import com.google.common.base.Optional;
 import org.opensaml.saml.saml2.core.Assertion;
 import org.opensaml.saml.saml2.core.Attribute;
 import org.opensaml.saml.saml2.core.AttributeStatement;
@@ -17,9 +16,7 @@ import uk.gov.ida.saml.security.validators.ValidatedResponse;
 
 import java.net.URI;
 import java.util.List;
-
-import static com.google.common.base.Optional.absent;
-import static com.google.common.base.Optional.fromNullable;
+import java.util.Optional;
 
 /*
 * Used by the fake relying parties, so there is a bit of dodgyness here.
@@ -36,17 +33,17 @@ public class InboundResponseFromHubUnmarshaller {
     }
 
     public InboundResponseFromHub fromSaml(ValidatedResponse validatedResponse, ValidatedAssertions validatedAssertions) {
-        Optional<PersistentId> persistentId = absent();
-        Optional<List<Attribute>> attributes = absent();
-        Optional<AuthnContext> authnContext = absent();
+        Optional<PersistentId> persistentId = Optional.empty();
+        Optional<List<Attribute>> attributes = Optional.empty();
+        Optional<AuthnContext> authnContext = Optional.empty();
 
         for (Assertion assertion : validatedAssertions.getAssertions()) {
             PassthroughAssertion outboundAssertion = passthroughAssertionUnmarshaller.fromAssertion(assertion);
             List<AttributeStatement> attributeStatements = assertion.getAttributeStatements();
             if (attributeStatements.size() == 1) {
-                attributes = fromNullable(attributeStatements.get(0).getAttributes());
+                attributes = Optional.ofNullable(attributeStatements.get(0).getAttributes());
             }
-            persistentId = fromNullable(outboundAssertion.getPersistentId());
+            persistentId = Optional.ofNullable(outboundAssertion.getPersistentId());
             authnContext = outboundAssertion.getAuthnContext();
         }
 

--- a/src/test/java/uk/gov/ida/rp/testrp/builders/PassthroughAssertionBuilder.java
+++ b/src/test/java/uk/gov/ida/rp/testrp/builders/PassthroughAssertionBuilder.java
@@ -1,22 +1,21 @@
 package uk.gov.ida.rp.testrp.builders;
 
-import com.google.common.base.Optional;
 import uk.gov.ida.saml.core.domain.AuthnContext;
 import uk.gov.ida.saml.core.domain.FraudDetectedDetails;
 import uk.gov.ida.saml.core.domain.PassthroughAssertion;
 import uk.gov.ida.saml.core.domain.PersistentId;
 
-import static com.google.common.base.Optional.absent;
-import static com.google.common.base.Optional.fromNullable;
+import java.util.Optional;
+
 import static uk.gov.ida.saml.core.test.builders.PersistentIdBuilder.aPersistentId;
 
 public class PassthroughAssertionBuilder {
 
     private PersistentId persistentId = aPersistentId().build();
-    private Optional<AuthnContext> authnContext = fromNullable(AuthnContext.LEVEL_1);
+    private Optional<AuthnContext> authnContext = Optional.of(AuthnContext.LEVEL_1);
     private String underlyingAssertion = "blob";
-    private Optional<FraudDetectedDetails> fraudDetectedDetails = absent();
-    private Optional<String> principalIpAddress = fromNullable("principal-ip-address");
+    private Optional<FraudDetectedDetails> fraudDetectedDetails = Optional.empty();
+    private Optional<String> principalIpAddress = Optional.of("principal-ip-address");
 
     public static PassthroughAssertionBuilder aPassthroughAssertion() {
         return new PassthroughAssertionBuilder();
@@ -28,7 +27,7 @@ public class PassthroughAssertionBuilder {
                 authnContext,
                 underlyingAssertion,
                 fraudDetectedDetails,
-                Optional.absent());
+                Optional.empty());
     }
 
     public PassthroughAssertion buildAuthnStatementAssertion() {
@@ -43,10 +42,10 @@ public class PassthroughAssertionBuilder {
     public PassthroughAssertion buildMatchingDatasetAssertion() {
         return new PassthroughAssertion(
                 persistentId,
-                Optional.absent(),
+                Optional.empty(),
                 underlyingAssertion,
                 fraudDetectedDetails,
-                Optional.absent());
+                Optional.empty());
     }
 
     public PassthroughAssertionBuilder withPersistentId(PersistentId persistentId) {
@@ -60,7 +59,7 @@ public class PassthroughAssertionBuilder {
     }
 
     public PassthroughAssertionBuilder withAuthnContext(AuthnContext authnContext) {
-        this.authnContext = fromNullable(authnContext);
+        this.authnContext = Optional.ofNullable(authnContext);
         return this;
     }
     public String buildMatchingDatasetAssertionAsString() {
@@ -72,12 +71,12 @@ public class PassthroughAssertionBuilder {
     }
 
     public PassthroughAssertionBuilder withFraudDetectedDetails(FraudDetectedDetails fraudDetectedDetails) {
-        this.fraudDetectedDetails = fromNullable(fraudDetectedDetails);
+        this.fraudDetectedDetails = Optional.ofNullable(fraudDetectedDetails);
         return this;
     }
 
     public PassthroughAssertionBuilder withPrincipalIpAddressSeenByIdp(String principalIpAddress) {
-        this.principalIpAddress = fromNullable(principalIpAddress);
+        this.principalIpAddress = Optional.ofNullable(principalIpAddress);
         return this;
     }
 }

--- a/src/test/java/uk/gov/ida/rp/testrp/controllogic/AuthnResponseReceiverHandlerTest.java
+++ b/src/test/java/uk/gov/ida/rp/testrp/controllogic/AuthnResponseReceiverHandlerTest.java
@@ -1,7 +1,5 @@
 package uk.gov.ida.rp.testrp.controllogic;
 
-import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableList;
 import com.squarespace.jersey2.guice.JerseyGuiceUtils;
 import org.joda.time.DateTime;
 import org.junit.Before;
@@ -23,11 +21,11 @@ import uk.gov.ida.saml.idp.stub.domain.InboundResponseFromHub;
 
 import java.net.URI;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Function;
 
-import static java.util.Optional.empty;
-import static java.util.Optional.ofNullable;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 import static org.opensaml.core.config.InitializationService.initialize;
@@ -53,8 +51,8 @@ public class AuthnResponseReceiverHandlerTest {
             REQUEST_ID,
             URI.create("pathUserWasTryingToAccess"),
             ISSUER,
-            ofNullable(1),
-            empty(),
+            Optional.of(1),
+            Optional.empty(),
             false,
             false,
             false,
@@ -74,11 +72,11 @@ public class AuthnResponseReceiverHandlerTest {
 
     @Test
     public void testSuccessResponse() {
-        InboundResponseFromHub inboundResponseFromHub = new InboundResponseFromHub(RESPONSE_ID, DateTime.now(), REQUEST_ID, ISSUER, DESTINATION, Optional.absent(), TransactionIdaStatus.Success, Optional.of(new PersistentId("persistentId")), Optional.of(AuthnContext.LEVEL_2));
+        InboundResponseFromHub inboundResponseFromHub = new InboundResponseFromHub(RESPONSE_ID, DateTime.now(), REQUEST_ID, ISSUER, DESTINATION, Optional.empty(), TransactionIdaStatus.Success, Optional.of(new PersistentId("persistentId")), Optional.of(AuthnContext.LEVEL_2));
         when(samlResponseDeserialiser.apply(samlResponse)).thenReturn(inboundResponseFromHub);
-        when(sessionRepository.getSession(SESSION_ID)).thenReturn(ofNullable(SESSION));
+        when(sessionRepository.getSession(SESSION_ID)).thenReturn(Optional.ofNullable(SESSION));
 
-        final ResponseFromHub responseFromHub = authnResponseReceiverHandler.handleResponse(samlResponse, ofNullable(SESSION_ID));
+        final ResponseFromHub responseFromHub = authnResponseReceiverHandler.handleResponse(samlResponse, Optional.ofNullable(SESSION_ID));
 
         assertThat(responseFromHub.getTransactionIdaStatus()).isEqualTo(TransactionIdaStatus.Success);
         assertThat(responseFromHub.getAttributes()).isEmpty();
@@ -90,16 +88,16 @@ public class AuthnResponseReceiverHandlerTest {
 
     @Test
     public void testAccountCreationResponse() {
-        final List<Attribute> attributes = ImmutableList.of(
+        final List<Attribute> attributes = Collections.unmodifiableList(Arrays.asList(
                 anAttribute().withFirstName("bob"),
                 anAttribute().withSurname("obo"),
-                anAttribute().withAddressHistory(Arrays.asList("Aviation House", "Whitechapel building"))
-        );
-        InboundResponseFromHub inboundResponseFromHub = new InboundResponseFromHub(RESPONSE_ID, DateTime.now(), REQUEST_ID, ISSUER, DESTINATION, Optional.fromNullable(attributes), TransactionIdaStatus.Success, Optional.of(new PersistentId("persistentId")), Optional.of(AuthnContext.LEVEL_2));
+                anAttribute().withAddressHistory(Arrays.asList("Aviation House", "Whitechapel building")
+        )));
+        InboundResponseFromHub inboundResponseFromHub = new InboundResponseFromHub(RESPONSE_ID, DateTime.now(), REQUEST_ID, ISSUER, DESTINATION, Optional.ofNullable(attributes), TransactionIdaStatus.Success, Optional.of(new PersistentId("persistentId")), Optional.of(AuthnContext.LEVEL_2));
         when(samlResponseDeserialiser.apply(samlResponse)).thenReturn(inboundResponseFromHub);
-        when(sessionRepository.getSession(SESSION_ID)).thenReturn(ofNullable(SESSION));
+        when(sessionRepository.getSession(SESSION_ID)).thenReturn(Optional.ofNullable(SESSION));
 
-        final ResponseFromHub responseFromHub = authnResponseReceiverHandler.handleResponse(samlResponse, ofNullable(SESSION_ID));
+        final ResponseFromHub responseFromHub = authnResponseReceiverHandler.handleResponse(samlResponse, Optional.ofNullable(SESSION_ID));
 
         assertThat(responseFromHub.getTransactionIdaStatus()).isEqualTo(TransactionIdaStatus.Success);
         assertThat(responseFromHub.getAttributes()).hasSameSizeAs(attributes);
@@ -111,10 +109,10 @@ public class AuthnResponseReceiverHandlerTest {
 
     @Test
     public void testNonSuccessResponse() {
-        InboundResponseFromHub inboundResponseFromHub = new InboundResponseFromHub(RESPONSE_ID, DateTime.now(), REQUEST_ID, ISSUER, DESTINATION, Optional.absent(), TransactionIdaStatus.NoAuthenticationContext, Optional.absent(), Optional.absent());
+        InboundResponseFromHub inboundResponseFromHub = new InboundResponseFromHub(RESPONSE_ID, DateTime.now(), REQUEST_ID, ISSUER, DESTINATION, Optional.empty(), TransactionIdaStatus.NoAuthenticationContext, Optional.empty(), Optional.empty());
         when(samlResponseDeserialiser.apply(samlResponse)).thenReturn(inboundResponseFromHub);
 
-        final ResponseFromHub responseFromHub = authnResponseReceiverHandler.handleResponse(samlResponse, java.util.Optional.empty());
+        final ResponseFromHub responseFromHub = authnResponseReceiverHandler.handleResponse(samlResponse, Optional.empty());
 
         assertThat(responseFromHub.getTransactionIdaStatus()).isEqualTo(TransactionIdaStatus.NoAuthenticationContext);
         assertThat(responseFromHub.getAttributes()).isEmpty();


### PR DESCRIPTION
-Remove unused saml-domain-objects dependency
-Remove unused saml-test-utils dependency
-Remove unused ida-saml-extensions-test dependency
-Specify type of keys in TestRpAppRule
-Change module to provide, due to dependency injection being removed from saml-security
-Change Optionals to use java utils instead of Guava

Solo - @jhjava