### PR TITLE
Fix jar name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -180,7 +180,7 @@ task intTest(type: Test) {
 ext.mainclass = 'uk.gov.ida.rp.testrp.TestRpApplication'
 mainClassName = ext.mainclass
 
-jar.baseName = 'ida-sample-rp'
+jar.baseName = 'verify-test-rp'
 
 task copyToLib(dependsOn: jar, type: Copy) {
     into "$buildDir/output/lib"


### PR DESCRIPTION
This commit fixes the name of the jar file produced by the build to be the new name of the repository, `verify-test-rp`.