### PR TITLE
EID-547 - Add eIDAS user, to ensure test-rp can function for cycle 3 …

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ def dependencyVersions = [
         ida_test_utils: '2.0.0-38',
         ida_dev_pki: '1.1.0-20',
         opensaml_version: "$opensaml",
-        saml_libs_version: "$opensaml-109",
+        saml_libs_version: "$opensaml-128",
         hub_saml: '3.3.0-123',
         stub_idp_saml: '3.3.0-68'
 ]

--- a/src/main/java/uk/gov/ida/rp/testrp/controllogic/MatchingServiceRequestHandler.java
+++ b/src/main/java/uk/gov/ida/rp/testrp/controllogic/MatchingServiceRequestHandler.java
@@ -49,6 +49,11 @@ public class MatchingServiceRequestHandler {
             return MatchingServiceResponseDto.NO_MATCH_RESPONSE;
         }
 
+        if (userMatch("Martin", "Riggs", "1970-04-12", matchingDataset ) &&
+                !matchingServiceRequestDto.getCycle3Dataset().isPresent()){
+            return MatchingServiceResponseDto.NO_MATCH_RESPONSE;
+        }
+
         if (session.isPresent() && session.get().forceLMSNoMatch()) {
             return MatchingServiceResponseDto.NO_MATCH_RESPONSE;
         }
@@ -79,7 +84,7 @@ public class MatchingServiceRequestHandler {
 
     private boolean userMatch(String firstName, String surname, String dateOfBirth, UniversalMatchingDatasetDto matchingDataset) {
         return matchingDataset.getSurnames().stream().anyMatch(s -> s.getValue().equals(surname)) &&
-            matchingDataset.getFirstName().equals(firstName) &&
+            matchingDataset.getFirstName().getValue().equals(firstName) &&
             matchingDataset.getDateOfBirth().getValue().toString().equals(dateOfBirth);
     }
 


### PR DESCRIPTION
…with stub country

-Responds with No Match from test-rp if stub-country-ec3 is used when signing in
to stub-country.
-Changed the userMatch method to get the value of the first name as
without getValue it will always come back as false
-Upgraded to latest version of saml-libs to stop memory leak from trust anchor