### PR TITLE
HUB-117: Adding a support for new journey hints

### DIFF
--- a/src/integration-test/java/uk/gov/ida/integrationTest/FullJourneyAppRuleTests.java
+++ b/src/integration-test/java/uk/gov/ida/integrationTest/FullJourneyAppRuleTests.java
@@ -83,6 +83,36 @@ public class FullJourneyAppRuleTests extends JerseyGuiceIntegrationTestAdapter {
     }
 
     @Test
+    public void ensureRegistrationHintWorks() throws MarshallingException, SignatureException {
+
+        URI uri = testRp.uriBuilder(Urls.TestRpUrls.SUCCESSFUL_REGISTER_RESOURCE)
+                .queryParam(JOURNEY_HINT_PARAM, JourneyHint.registration)
+                .build();
+        
+        RequestParamHelper.RequestParams requestParams = journeyHelper.startNewJourneyFromTestRp(uri);
+        String hashedPid = journeyHelper.doASuccessfulMatchInLocalMatchingService(testRp.uri(Urls.TestRpUrls.LOCAL_MATCHING_SERVICE_RESOURCE), requestParams.getRequestId().get());
+        Response responseFromHub = journeyHelper.postSuccessAuthnResponseBackFromHub(testRp.uri(Urls.TestRpUrls.LOGIN_RESOURCE), hashedPid, requestParams.getRelayState().get());
+
+        Response testRpSuccessPage = journeyHelper.getSuccessPage(responseFromHub.getHeaderString("Location"), responseFromHub.getCookies().get(TEST_RP_SESSION_COOKIE_NAME));
+        assertThat(testRpSuccessPage.readEntity(String.class)).contains("LEVEL_2");
+    }
+
+    @Test
+    public void ensureSignInHintWorks() throws MarshallingException, SignatureException {
+
+        URI uri = testRp.uriBuilder(Urls.TestRpUrls.SUCCESSFUL_REGISTER_RESOURCE)
+                .queryParam(JOURNEY_HINT_PARAM, JourneyHint.sign_in)
+                .build();
+
+        RequestParamHelper.RequestParams requestParams = journeyHelper.startNewJourneyFromTestRp(uri);
+        String hashedPid = journeyHelper.doASuccessfulMatchInLocalMatchingService(testRp.uri(Urls.TestRpUrls.LOCAL_MATCHING_SERVICE_RESOURCE), requestParams.getRequestId().get());
+        Response responseFromHub = journeyHelper.postSuccessAuthnResponseBackFromHub(testRp.uri(Urls.TestRpUrls.LOGIN_RESOURCE), hashedPid, requestParams.getRelayState().get());
+
+        Response testRpSuccessPage = journeyHelper.getSuccessPage(responseFromHub.getHeaderString("Location"), responseFromHub.getCookies().get(TEST_RP_SESSION_COOKIE_NAME));
+        assertThat(testRpSuccessPage.readEntity(String.class)).contains("LEVEL_2");
+    }
+
+    @Test
     public void ensureNewJourneysWorkFromStartPageWhenLoggedIn() throws MarshallingException, SignatureException {
 
         final RequestParamHelper.RequestParams requestParams = journeyHelper.startNewJourneyFromTestRp(testRp.uri(Urls.TestRpUrls.SUCCESSFUL_REGISTER_RESOURCE));

--- a/src/main/java/uk/gov/ida/rp/testrp/authentication/SessionFactory.java
+++ b/src/main/java/uk/gov/ida/rp/testrp/authentication/SessionFactory.java
@@ -132,7 +132,7 @@ public class SessionFactory extends AbstractContainerRequestValueFactory<Session
                 Optional<String> sessionId = Optional.ofNullable(cookieNameValueMap.get(TEST_RP_SESSION_COOKIE_NAME).getValue());
                 if (sessionId.isPresent()) {
                     Optional<Session> result = authenticator.authenticate(new SessionId(sessionId.get()));
-                    if (result.isPresent() && !(journeyHint.isPresent() && journeyHint.get().equals(JourneyHint.submission_confirmation))) {
+                    if (result.isPresent() && !(journeyHint.isPresent() && EnumUtils.isValidEnum(JourneyHint.class, journeyHint.get().toString()))) {
                         return result.get();
                     }
                 }

--- a/src/main/java/uk/gov/ida/rp/testrp/authentication/SessionFactory.java
+++ b/src/main/java/uk/gov/ida/rp/testrp/authentication/SessionFactory.java
@@ -132,7 +132,7 @@ public class SessionFactory extends AbstractContainerRequestValueFactory<Session
                 Optional<String> sessionId = Optional.ofNullable(cookieNameValueMap.get(TEST_RP_SESSION_COOKIE_NAME).getValue());
                 if (sessionId.isPresent()) {
                     Optional<Session> result = authenticator.authenticate(new SessionId(sessionId.get()));
-                    if (result.isPresent() && !(journeyHint.isPresent() && EnumUtils.isValidEnum(JourneyHint.class, journeyHint.get().toString()))) {
+                    if (result.isPresent() && !(journeyHint.isPresent() && EnumUtils.isValidEnum(JourneyHint.class, journeyHint.get().name()))) {
                         return result.get();
                     }
                 }

--- a/src/main/java/uk/gov/ida/rp/testrp/domain/JourneyHint.java
+++ b/src/main/java/uk/gov/ida/rp/testrp/domain/JourneyHint.java
@@ -1,5 +1,7 @@
 package uk.gov.ida.rp.testrp.domain;
 
 public enum JourneyHint {
-    submission_confirmation
+    submission_confirmation,
+    registration,
+    sign_in
 }

--- a/src/main/resources/uk/gov/ida/rp/testrp/views/landingPage.jade
+++ b/src/main/resources/uk/gov/ida/rp/testrp/views/landingPage.jade
@@ -35,6 +35,14 @@ block content
         input#forceauthn-noc3-rp(type="checkbox", name="forceauthn-noc3-rp", onclick='setNoc3()')
         | Use ForceAuthn and no-cycle3 test RP?
 
+      p 
+        label(for="journey_hint") Journey hint:
+        select(name="journey_hint")
+          option(value="none", selected="true") None
+          option(value="submission_confirmation") Non-repudiation
+          option(value="registration") Registration
+          option(value="sign_in") Sign-in
+
       p
         label(for="rp-name") Overridden RP Name
         input#rp-name(type="textbox", name="rp-name")


### PR DESCRIPTION
Frontend can now receive 'registration' and 'sign_in' journey hints to
redirect users to the correct pages. This is in response to the new
GOV.UK start page where users now have option to Sign-in or Create
account but currently we send them to the same hub start page no
matter what they choose.

Co-Authored-By: Rylan Gooch <rylan.gooch@digital.cabinet-office.gov.uk>