### PR TITLE
Eid 647

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,9 @@ apply plugin: 'idaJar'
 apply plugin: 'idea'
 apply plugin: 'application'
 
+compileJava.options.encoding = "UTF-8"
+compileTestJava.options.encoding = "UTF-8"
+
 repositories {
     maven { url 'https://artifactory.ida.digital.cabinet-office.gov.uk/artifactory/whitelisted-repos/' }
 }

--- a/src/integration-test/java/uk/gov/ida/integrationTest/FullJourneyAppRuleTests.java
+++ b/src/integration-test/java/uk/gov/ida/integrationTest/FullJourneyAppRuleTests.java
@@ -101,7 +101,7 @@ public class FullJourneyAppRuleTests extends JerseyGuiceIntegrationTestAdapter {
     public void ensureSignInHintWorks() throws MarshallingException, SignatureException {
 
         URI uri = testRp.uriBuilder(Urls.TestRpUrls.SUCCESSFUL_REGISTER_RESOURCE)
-                .queryParam(JOURNEY_HINT_PARAM, JourneyHint.sign_in)
+                .queryParam(JOURNEY_HINT_PARAM, JourneyHint.uk_idp_sign_in)
                 .build();
 
         RequestParamHelper.RequestParams requestParams = journeyHelper.startNewJourneyFromTestRp(uri);

--- a/src/integration-test/java/uk/gov/ida/integrationTest/TestRpEidasJourneyAppRuleTest.java
+++ b/src/integration-test/java/uk/gov/ida/integrationTest/TestRpEidasJourneyAppRuleTest.java
@@ -54,7 +54,7 @@ public class TestRpEidasJourneyAppRuleTest extends JerseyGuiceIntegrationTestAda
             .get(Response.class);
 
         String html = response.readEntity(String.class);
-        assertTrue(html.contains("name=\"eidas_journey\""));
+        assertTrue(html.contains("value=\"eidas_sign_in\""));
     }
 
     @Test
@@ -68,7 +68,7 @@ public class TestRpEidasJourneyAppRuleTest extends JerseyGuiceIntegrationTestAda
             .get(Response.class);
 
         String html = response.readEntity(String.class);
-        assertTrue(html.contains("name=\"eidas_journey\""));
+        assertTrue(html.contains("value=\"eidas_sign_in\""));
     }
 
 }

--- a/src/main/java/uk/gov/ida/rp/testrp/authentication/SessionFactory.java
+++ b/src/main/java/uk/gov/ida/rp/testrp/authentication/SessionFactory.java
@@ -96,7 +96,6 @@ public class SessionFactory extends AbstractContainerRequestValueFactory<Session
             }
         }
 
-        // TODO: remove the EIDAS_PARAM completely
         if (containsQueryParam(EIDAS_PARAM) && !journeyHint.isPresent()) {
             journeyHint = Optional.of(JourneyHint.eidas_sign_in);
         }

--- a/src/main/java/uk/gov/ida/rp/testrp/authentication/SessionFactory.java
+++ b/src/main/java/uk/gov/ida/rp/testrp/authentication/SessionFactory.java
@@ -96,12 +96,16 @@ public class SessionFactory extends AbstractContainerRequestValueFactory<Session
             }
         }
 
+        // TODO: remove the EIDAS_PARAM completely
+        if (containsQueryParam(EIDAS_PARAM) && !journeyHint.isPresent()) {
+            journeyHint = Optional.of(JourneyHint.eidas_sign_in);
+        }
+
         return getUser(
             accessToken,
             overriddenRpName,
             journeyHint,
             forceAuthentication,
-            containsQueryParam(EIDAS_PARAM),
             containsQueryParam(NO_MATCH),
             containsQueryParam(FAIL_ACCOUNT_CREATION));
     }
@@ -120,7 +124,6 @@ public class SessionFactory extends AbstractContainerRequestValueFactory<Session
             Optional<String> overriddenRpName,
             Optional<JourneyHint> journeyHint,
             boolean forceAuthentication,
-            boolean isEidas,
             boolean forceLMSNoMatch,
             boolean forceLMSUserAccountCreationFail) {
 
@@ -149,7 +152,6 @@ public class SessionFactory extends AbstractContainerRequestValueFactory<Session
                 accessToken,
                 journeyHint,
                 forceAuthentication,
-                isEidas,
                 forceLMSNoMatch,
                 forceLMSUserAccountCreationFail);
 

--- a/src/main/java/uk/gov/ida/rp/testrp/controllogic/AuthnRequestSenderHandler.java
+++ b/src/main/java/uk/gov/ida/rp/testrp/controllogic/AuthnRequestSenderHandler.java
@@ -55,7 +55,6 @@ public class AuthnRequestSenderHandler {
             Optional<AccessToken> accessToken,
             Optional<JourneyHint> journeyHint,
             boolean forceAuthentication,
-            boolean isEidas,
             boolean forceLMSNoMatch,
             boolean forceLMSUserAccountCreationFail) {
 
@@ -67,9 +66,9 @@ public class AuthnRequestSenderHandler {
             LOG.info("USED_TOKEN:{},{}", accessToken.get(), requestId);
         }
 
-        final SessionId sessionId = sessionRepository.newSession(requestId, requestUri, issuerId, assertionConsumerServiceIndex, journeyHint, forceAuthentication, forceLMSNoMatch, forceLMSUserAccountCreationFail, isEidas);
+        final SessionId sessionId = sessionRepository.newSession(requestId, requestUri, issuerId, assertionConsumerServiceIndex, journeyHint, forceAuthentication, forceLMSNoMatch, forceLMSUserAccountCreationFail);
 
-        return samlRequestFactory.sendSamlMessage(authnRequestToStringTransformer.apply(requestToSendToHub), sessionId, getHubSsoUri(), journeyHint, isEidas);
+        return samlRequestFactory.sendSamlMessage(authnRequestToStringTransformer.apply(requestToSendToHub), sessionId, getHubSsoUri(), journeyHint);
     }
 
     private URI getHubSsoUri() {

--- a/src/main/java/uk/gov/ida/rp/testrp/domain/JourneyHint.java
+++ b/src/main/java/uk/gov/ida/rp/testrp/domain/JourneyHint.java
@@ -3,5 +3,7 @@ package uk.gov.ida.rp.testrp.domain;
 public enum JourneyHint {
     submission_confirmation,
     registration,
-    sign_in
+    uk_idp_sign_in,
+    eidas_sign_in,
+    unspecified
 }

--- a/src/main/java/uk/gov/ida/rp/testrp/domain/JourneyHint.java
+++ b/src/main/java/uk/gov/ida/rp/testrp/domain/JourneyHint.java
@@ -5,5 +5,6 @@ public enum JourneyHint {
     registration,
     uk_idp_sign_in,
     eidas_sign_in,
-    unspecified
+    unspecified,
+    other_value_xyz
 }

--- a/src/main/java/uk/gov/ida/rp/testrp/domain/JourneyHint.java
+++ b/src/main/java/uk/gov/ida/rp/testrp/domain/JourneyHint.java
@@ -5,6 +5,5 @@ public enum JourneyHint {
     registration,
     uk_idp_sign_in,
     eidas_sign_in,
-    unspecified,
-    other_value_xyz
+    unspecified
 }

--- a/src/main/java/uk/gov/ida/rp/testrp/repositories/Session.java
+++ b/src/main/java/uk/gov/ida/rp/testrp/repositories/Session.java
@@ -20,11 +20,10 @@ public class Session implements Principal {
     private final boolean forceAuthentication;
     private final boolean forceLMSUserAccountCreationFail;
     private final boolean forceLMSNoMatch;
-    private final boolean isEidas;
     private final URI pathUserWasTryingToAccess;
     private Optional<String> matchedHashedPidForSession;
 
-    public Session(SessionId sessionId, String requestId, URI pathUserWasTryingToAccess, String issuerId, Optional<Integer> assertionConsumerServiceIndex, Optional<JourneyHint> journeyHint, boolean forceAuthentication, boolean forceLMSNoMatch, boolean forceLMSUserAccountCreationFail, boolean isEidas) {
+    public Session(SessionId sessionId, String requestId, URI pathUserWasTryingToAccess, String issuerId, Optional<Integer> assertionConsumerServiceIndex, Optional<JourneyHint> journeyHint, boolean forceAuthentication, boolean forceLMSNoMatch, boolean forceLMSUserAccountCreationFail) {
         this.sessionId = sessionId;
         this.requestId = requestId;
         // remove JOURNEY_HINT_PARAM, otherwise Cycle3UserFactory will bounce the user back to hub
@@ -36,12 +35,11 @@ public class Session implements Principal {
         this.forceAuthentication = forceAuthentication;
         this.forceLMSUserAccountCreationFail = forceLMSUserAccountCreationFail;
         this.forceLMSNoMatch = forceLMSNoMatch;
-        this.isEidas = isEidas;
         this.matchedHashedPidForSession = Optional.empty();
     }
 
     public Session(SessionId sessionId, String requestId, URI pathUserWasTryingToAccess, String issuerId, Optional<Integer> assertionConsumerServiceIndex, Optional<JourneyHint> journeyHint) {
-        this(sessionId, requestId, pathUserWasTryingToAccess, issuerId, assertionConsumerServiceIndex, journeyHint, false, false, false, false);
+        this(sessionId, requestId, pathUserWasTryingToAccess, issuerId, assertionConsumerServiceIndex, journeyHint, false, false, false);
     }
 
     public boolean forceLMSUserAccountCreationFail() {

--- a/src/main/java/uk/gov/ida/rp/testrp/repositories/SessionRepository.java
+++ b/src/main/java/uk/gov/ida/rp/testrp/repositories/SessionRepository.java
@@ -10,7 +10,6 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import java.net.URI;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 
 import static uk.gov.ida.rp.testrp.contract.UnknownUserCreationResponseDto.FAILURE_RESPONSE;
@@ -34,9 +33,9 @@ public class SessionRepository {
         return Optional.ofNullable(sessions.asMap().get(sessionId));
     }
 
-    public SessionId newSession(String requestId, URI requestUri, String issuerId, Optional<Integer> assertionConsumerServiceIndex, Optional<JourneyHint> journeyHint, boolean forceAuthentication, boolean forceLMSNoMatch, boolean forceLMSUserAccountCreationFail, boolean isEidas) {
+    public SessionId newSession(String requestId, URI requestUri, String issuerId, Optional<Integer> assertionConsumerServiceIndex, Optional<JourneyHint> journeyHint, boolean forceAuthentication, boolean forceLMSNoMatch, boolean forceLMSUserAccountCreationFail) {
         SessionId sessionId = SessionId.createNewSessionId();
-        Session session = new Session(sessionId, requestId, requestUri, issuerId, assertionConsumerServiceIndex, journeyHint, forceAuthentication, forceLMSNoMatch, forceLMSUserAccountCreationFail, isEidas);
+        Session session = new Session(sessionId, requestId, requestUri, issuerId, assertionConsumerServiceIndex, journeyHint, forceAuthentication, forceLMSNoMatch, forceLMSUserAccountCreationFail);
         updateSession(sessionId, session);
         return sessionId;
     }

--- a/src/main/java/uk/gov/ida/rp/testrp/resources/HeadlessRpResource.java
+++ b/src/main/java/uk/gov/ida/rp/testrp/resources/HeadlessRpResource.java
@@ -4,6 +4,7 @@ import org.glassfish.jersey.server.ContainerRequest;
 import uk.gov.ida.rp.testrp.Urls;
 import uk.gov.ida.rp.testrp.controllogic.AuthnRequestSenderHandler;
 import uk.gov.ida.rp.testrp.controllogic.AuthnResponseReceiverHandler;
+import uk.gov.ida.rp.testrp.domain.JourneyHint;
 import uk.gov.ida.saml.core.domain.TransactionIdaStatus;
 import uk.gov.ida.saml.idp.stub.domain.InboundResponseFromHub;
 
@@ -49,9 +50,8 @@ public class HeadlessRpResource {
                 Optional.ofNullable(WORKING_ASSERTION_CONSUMER_SERVICE_INDEX),
                 "headless",
                 Optional.empty(),
-                Optional.empty(),
+                eidas.map(x -> JourneyHint.eidas_sign_in),
                 false,
-                eidas.isPresent(),
                 false,
                 false);
     }

--- a/src/main/java/uk/gov/ida/rp/testrp/views/SamlAuthnRequestRedirectViewFactory.java
+++ b/src/main/java/uk/gov/ida/rp/testrp/views/SamlAuthnRequestRedirectViewFactory.java
@@ -19,18 +19,17 @@ public class SamlAuthnRequestRedirectViewFactory {
         // intentionally blank
     }
 
-    public Response sendSamlMessage(String messageToSend, SessionId relayState, URI targetUriFromSamlEndpoint, Optional<JourneyHint> journeyHint, boolean isEidas) {
-        return getResponse(messageToSend, relayState, targetUriFromSamlEndpoint, journeyHint, isEidas);
+    public Response sendSamlMessage(String messageToSend, SessionId relayState, URI targetUriFromSamlEndpoint, Optional<JourneyHint> journeyHint) {
+        return getResponse(messageToSend, relayState, targetUriFromSamlEndpoint, journeyHint);
     }
 
     private Response getResponse(
             String samlMessage,
             SessionId relayState,
             URI targetUriFromSamlEndpoint,
-            Optional<JourneyHint> journeyHint,
-            boolean isEidas) {
+            Optional<JourneyHint> journeyHint) {
 
-        SamlRedirectView samlFormPostingView = new SamlRedirectView(targetUriFromSamlEndpoint, samlMessage, relayState, journeyHint, isEidas);
+        SamlRedirectView samlFormPostingView = new SamlRedirectView(targetUriFromSamlEndpoint, samlMessage, relayState, journeyHint);
         return Response.ok(samlFormPostingView)
             .header(HttpHeaders.CACHE_CONTROL, "no-cache, no-store")
             .header(HttpHeaders.PRAGMA, "no-cache")

--- a/src/main/java/uk/gov/ida/rp/testrp/views/SamlRedirectView.java
+++ b/src/main/java/uk/gov/ida/rp/testrp/views/SamlRedirectView.java
@@ -12,19 +12,16 @@ public class SamlRedirectView extends View {
     private String responseBody;
     private SessionId relayState;
     private final Optional<JourneyHint> journeyHint;
-    private final boolean isEidas;
 
     public SamlRedirectView(URI targetUri,
                             String base64EncodedResponseBody,
                             SessionId relayState,
-                            Optional<JourneyHint> journeyHint,
-                            final boolean isEidas) {
+                            Optional<JourneyHint> journeyHint) {
         super("samlRedirectView.ftl");
         this.targetUri = targetUri;
         this.responseBody = base64EncodedResponseBody;
         this.relayState = relayState;
         this.journeyHint = journeyHint;
-        this.isEidas = isEidas;
     }
 
     public URI getTargetUri() {
@@ -45,9 +42,5 @@ public class SamlRedirectView extends View {
 
     public String getJourneyHint() {
         return journeyHint.isPresent()?journeyHint.get().name():"";
-    }
-
-    public boolean getIsEidas() {
-        return isEidas;
     }
 }

--- a/src/main/resources/uk/gov/ida/rp/testrp/views/landingPage.jade
+++ b/src/main/resources/uk/gov/ida/rp/testrp/views/landingPage.jade
@@ -45,7 +45,9 @@ block content
           option(value="none", selected="true") None
           option(value="submission_confirmation") Non-repudiation
           option(value="registration") Registration
-          option(value="sign_in") Sign-in
+          option(value="unspecified") Unspecified
+          option(value="uk_idp_sign_in") Sign-in with Verify
+          option(value="eidas_sign_in") Sign-in with eIDAS
 
       p
         label(for="rp-name") Overridden RP Name

--- a/src/main/resources/uk/gov/ida/rp/testrp/views/landingPage.jade
+++ b/src/main/resources/uk/gov/ida/rp/testrp/views/landingPage.jade
@@ -45,10 +45,9 @@ block content
           option(value="none", selected="true") None
           option(value="submission_confirmation") Non-repudiation
           option(value="registration") Registration
-          option(value="unspecified") Unspecified
           option(value="uk_idp_sign_in") Sign-in with Verify
           option(value="eidas_sign_in") Sign-in with eIDAS
-          option(value="other_value_xyz") Other value XYZ
+          option(value="unspecified") Unspecified
 
       p
         label(for="rp-name") Overridden RP Name

--- a/src/main/resources/uk/gov/ida/rp/testrp/views/landingPage.jade
+++ b/src/main/resources/uk/gov/ida/rp/testrp/views/landingPage.jade
@@ -48,6 +48,7 @@ block content
           option(value="unspecified") Unspecified
           option(value="uk_idp_sign_in") Sign-in with Verify
           option(value="eidas_sign_in") Sign-in with eIDAS
+          option(value="other_value_xyz") Other value XYZ
 
       p
         label(for="rp-name") Overridden RP Name

--- a/src/main/resources/uk/gov/ida/rp/testrp/views/samlRedirectView.ftl
+++ b/src/main/resources/uk/gov/ida/rp/testrp/views/samlRedirectView.ftl
@@ -47,9 +47,6 @@
     <#if showJourneyHint>
         <input type="hidden" value="${journeyHint}" name="journey_hint"/>
     </#if>
-    <#if isEidas>
-        <input type="hidden" value="true" name="eidas_journey"/>
-    </#if>
     <button class='verify-button' id="continue-button">Continue</button>
 </form>
 </body>

--- a/src/test/java/uk/gov/ida/rp/testrp/authentication/AuthnRequestSenderHandlerTest.java
+++ b/src/test/java/uk/gov/ida/rp/testrp/authentication/AuthnRequestSenderHandlerTest.java
@@ -80,16 +80,16 @@ public class AuthnRequestSenderHandlerTest {
     public void sendAuthnRequest_shouldUseDefaultTargetUriWhenTargetUriNotSpecified() throws Exception {
         final SessionId relayState = SessionId.createNewSessionId();
 
-        when(sessionRepository.newSession(any(), eq(requestUri), any(), any(), any(), eq(forceAuthentication), eq(false), eq(false), eq(false))).thenReturn(relayState);
+        when(sessionRepository.newSession(any(), eq(requestUri), any(), any(), any(), eq(forceAuthentication), eq(false), eq(false))).thenReturn(relayState);
         when(configuration.getSamlConfiguration()).thenReturn(samlConfiguration);
         when(samlConfiguration.getEntityId()).thenReturn("entity id");
 
         this.manager.sendAuthnRequest(requestUri, Optional.empty(), "test-rp",
-            Optional.empty(), Optional.empty(), false,
+            Optional.empty(), Optional.empty(),
             false, false, false);
 
         verify(samlRequestFactory).sendSamlMessage(
-            eq(null), eq(relayState), eq(new URI(hubSsoEndpoint)), eq(Optional.empty()), eq(false));
+            eq(null), eq(relayState), eq(new URI(hubSsoEndpoint)), eq(Optional.empty()));
     }
 
     @Test
@@ -99,7 +99,7 @@ public class AuthnRequestSenderHandlerTest {
         ArgumentCaptor<AuthnRequestFromTransaction> captor = ArgumentCaptor.forClass(AuthnRequestFromTransaction.class);
         when(configuration.getSamlConfiguration()).thenReturn(new TestSamlConfiguration(issuerId));
 
-        this.manager.sendAuthnRequest(requestUri, Optional.empty(), rpName, Optional.empty(), Optional.empty(), forceAuthentication, false, false, false);
+        this.manager.sendAuthnRequest(requestUri, Optional.empty(), rpName, Optional.empty(), Optional.empty(), forceAuthentication, false, false);
 
         verify(authnRequestToStringTransformer).apply(captor.capture());
         assertThat(captor.getValue().getForceAuthentication().get()).isEqualTo(forceAuthentication);
@@ -112,7 +112,7 @@ public class AuthnRequestSenderHandlerTest {
         ArgumentCaptor<AuthnRequestFromTransaction> captor = ArgumentCaptor.forClass(AuthnRequestFromTransaction.class);
         when(configuration.getSamlConfiguration()).thenReturn(new TestSamlConfiguration(issuerId));
         boolean forceAuthn = true;
-        this.manager.sendAuthnRequest(requestUri, Optional.empty(), rpName, Optional.empty(), Optional.empty(), forceAuthn, false, false, false);
+        this.manager.sendAuthnRequest(requestUri, Optional.empty(), rpName, Optional.empty(), Optional.empty(), forceAuthn, false, false);
 
         verify(authnRequestToStringTransformer).apply(captor.capture());
         assertThat(captor.getValue().getForceAuthentication().get()).isEqualTo(forceAuthn);

--- a/src/test/java/uk/gov/ida/rp/testrp/authentication/TestRpSessionFactoryTest.java
+++ b/src/test/java/uk/gov/ida/rp/testrp/authentication/TestRpSessionFactoryTest.java
@@ -11,6 +11,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import uk.gov.ida.common.SessionId;
 import uk.gov.ida.rp.testrp.TestRpConfiguration;
 import uk.gov.ida.rp.testrp.controllogic.AuthnRequestSenderHandler;
+import uk.gov.ida.rp.testrp.domain.JourneyHint;
 import uk.gov.ida.rp.testrp.repositories.Session;
 import uk.gov.ida.rp.testrp.tokenservice.AccessTokenValidator;
 
@@ -76,7 +77,6 @@ public class TestRpSessionFactoryTest {
             Optional.empty(),
             false,
             false,
-            false,
             false);
 
     @Before
@@ -128,9 +128,8 @@ public class TestRpSessionFactoryTest {
                 any(),
                 anyString(),
                 any(),
-                any(),
+                eq(Optional.of(JourneyHint.eidas_sign_in)),
                 anyBoolean(),
-                eq(true),
                 anyBoolean(),
                 anyBoolean()
         );

--- a/src/test/java/uk/gov/ida/rp/testrp/controllogic/AuthnResponseReceiverHandlerTest.java
+++ b/src/test/java/uk/gov/ida/rp/testrp/controllogic/AuthnResponseReceiverHandlerTest.java
@@ -65,7 +65,6 @@ public class AuthnResponseReceiverHandlerTest {
             Optional.empty(),
             false,
             false,
-            false,
             false);
 
     @Mock

--- a/src/test/java/uk/gov/ida/rp/testrp/controllogic/TestRpMatchingServiceRequestHandlerTest.java
+++ b/src/test/java/uk/gov/ida/rp/testrp/controllogic/TestRpMatchingServiceRequestHandlerTest.java
@@ -215,7 +215,6 @@ public class TestRpMatchingServiceRequestHandlerTest {
                 Optional.empty(),
                 false,
                 forceNoMatch,
-                forceUserAccountCreationFail,
-                false);
+                forceUserAccountCreationFail);
     }
 }

--- a/src/test/java/uk/gov/ida/rp/testrp/resources/TestRpResourceTest.java
+++ b/src/test/java/uk/gov/ida/rp/testrp/resources/TestRpResourceTest.java
@@ -88,7 +88,6 @@ public class TestRpResourceTest {
                 Optional.empty(),
                 false,
                 false,
-                false,
                 false);
 
         TestRpSuccessPageView successPageView = resource.getSuccessfulRegister(session, Optional.empty(), Optional.of("unit-test-rp"), Optional.of(LevelOfAssuranceDto.LEVEL_1));


### PR DESCRIPTION
- We used to specify an `eidas_journey` parameter to frontend to skip to the country picker.
- We now have a `eidas_sign_in` value for the `journey_hint` parameter which we have replaced it with.