### PR TITLE
EID-981 - Ensure headless-rp success end points goes to blue page

### DIFF
--- a/src/main/java/uk/gov/ida/rp/testrp/Urls.java
+++ b/src/main/java/uk/gov/ida/rp/testrp/Urls.java
@@ -5,6 +5,7 @@ public interface Urls {
     String LOGIN_PATH = "/login";
     String SUCCESSFUL_REGISTER_PATH = "/success";
     String LOGOUT_PATH = "/logout";
+    String SUCCESSFUL_IDP_PATH = "/success-idp" ;
 
     interface TestRpUrls {
         String TEST_RP_ROOT = "/test-rp";

--- a/src/main/java/uk/gov/ida/rp/testrp/resources/HeadlessRpResource.java
+++ b/src/main/java/uk/gov/ida/rp/testrp/resources/HeadlessRpResource.java
@@ -3,9 +3,7 @@ package uk.gov.ida.rp.testrp.resources;
 import org.glassfish.jersey.server.ContainerRequest;
 import uk.gov.ida.rp.testrp.Urls;
 import uk.gov.ida.rp.testrp.controllogic.AuthnRequestSenderHandler;
-import uk.gov.ida.rp.testrp.controllogic.AuthnResponseReceiverHandler;
 import uk.gov.ida.rp.testrp.domain.JourneyHint;
-import uk.gov.ida.saml.core.domain.TransactionIdaStatus;
 import uk.gov.ida.saml.idp.stub.domain.InboundResponseFromHub;
 
 import javax.inject.Inject;
@@ -16,7 +14,6 @@ import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -43,14 +40,28 @@ public class HeadlessRpResource {
     @GET
     @Path(Urls.SUCCESSFUL_REGISTER_PATH)
     public Response makeAuthnRequest(
-            @Context ContainerRequest containerRequest,
-            @QueryParam("eidas") Optional<String> eidas) {
+            @Context ContainerRequest containerRequest) {
         return authnRequestSenderHandler.sendAuthnRequest(
                 containerRequest.getUriInfo().getRequestUri(),
                 Optional.ofNullable(WORKING_ASSERTION_CONSUMER_SERVICE_INDEX),
                 "headless",
                 Optional.empty(),
-                eidas.map(x -> JourneyHint.eidas_sign_in),
+                Optional.of(JourneyHint.uk_idp_start),
+                false,
+                false,
+                false);
+    }
+
+    @GET
+    @Path(Urls.SUCCESSFUL_IDP_PATH)
+    public Response makeIdpAuthnRequest(
+            @Context ContainerRequest containerRequest) {
+        return authnRequestSenderHandler.sendAuthnRequest(
+                containerRequest.getUriInfo().getRequestUri(),
+                Optional.ofNullable(WORKING_ASSERTION_CONSUMER_SERVICE_INDEX),
+                "headless",
+                Optional.empty(),
+                Optional.of(JourneyHint.uk_idp_start),
                 false,
                 false,
                 false);


### PR DESCRIPTION
- We need to enable eidas for headless-rp so that we can perform smoke
tests on the middleware. Enabling eIDAS will add the prove-identity page
which will cause the idp smoke tests to fail.
- Use the uk_idp_start journey hint to ensure /success for headless rp always go to the
blue pages, whilst we enable headless rp for each environment.
- We will then switch over the current smoke tests to use the new end point /success-idp and use the /success for the eIDAS smoke tests. 
- This is just the first phase of ensuring the eIDAS smoke tests use headless-rp