### PR TITLE
EID-981 - Remove journey hint from headless-rp '/success' end point

### DIFF
--- a/src/integration-test/java/uk/gov/ida/integrationTest/TestRpEidasJourneyAppRuleTest.java
+++ b/src/integration-test/java/uk/gov/ida/integrationTest/TestRpEidasJourneyAppRuleTest.java
@@ -18,6 +18,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.net.URI;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class TestRpEidasJourneyAppRuleTest extends IntegrationTestHelper {
@@ -50,8 +51,8 @@ public class TestRpEidasJourneyAppRuleTest extends IntegrationTestHelper {
     }
 
     @Test
-    public void getHeadlessRpSamlRedirectView_shouldHaveIdpStartJourneyHint() {
-        URI uri = testRp.uriBuilder(Urls.HeadlessUrls.SUCCESS_PATH)
+    public void getHeadlessRpIdpStartSamlRedirectView_shouldHaveIdpStartJourneyHint() {
+        URI uri = testRp.uriBuilder(Urls.HeadlessUrls.SUCCESS_PATH_IDP)
             .build();
 
         Response response = client.target(uri)
@@ -59,6 +60,26 @@ public class TestRpEidasJourneyAppRuleTest extends IntegrationTestHelper {
             .get(Response.class);
 
         String html = response.readEntity(String.class);
+
         assertTrue(html.contains("value=\"uk_idp_start\""));
+    }
+
+    @Test
+    public void getHeadlessRpStartSamlRedirectView_shouldHaveNoJourneyHint() {
+        URI uri = testRp.uriBuilder(Urls.HeadlessUrls.SUCCESS_PATH)
+                .build();
+
+        Response response = client.target(uri)
+                .request(MediaType.TEXT_HTML)
+                .get(Response.class);
+
+        String html = response.readEntity(String.class);
+
+        assertFalse(html.contains("value=\"submission_confirmation\""));
+        assertFalse(html.contains("value=\"registration\""));
+        assertFalse(html.contains("value=\"uk_idp_sign_in\""));
+        assertFalse(html.contains("value=\"uk_idp_start\""));
+        assertFalse(html.contains("value=\"eidas_sign_in\""));
+        assertFalse(html.contains("value=\"unspecified\""));
     }
 }

--- a/src/main/java/uk/gov/ida/rp/testrp/Urls.java
+++ b/src/main/java/uk/gov/ida/rp/testrp/Urls.java
@@ -24,6 +24,7 @@ public interface Urls {
         String HEADLESS_ROOT = "/headless-rp";
         String LOGIN_PATH = Urls.LOGIN_PATH;
         String SUCCESS_PATH = HEADLESS_ROOT + SUCCESSFUL_REGISTER_PATH;
+        String SUCCESS_PATH_IDP = HEADLESS_ROOT + SUCCESSFUL_IDP_PATH;
     }
 
     interface Cookies {

--- a/src/main/java/uk/gov/ida/rp/testrp/resources/HeadlessRpResource.java
+++ b/src/main/java/uk/gov/ida/rp/testrp/resources/HeadlessRpResource.java
@@ -46,7 +46,7 @@ public class HeadlessRpResource {
                 Optional.ofNullable(WORKING_ASSERTION_CONSUMER_SERVICE_INDEX),
                 "headless",
                 Optional.empty(),
-                Optional.of(JourneyHint.uk_idp_start),
+                Optional.empty(),
                 false,
                 false,
                 false);


### PR DESCRIPTION
- Now that the smoke tests use the new '/success-idp' end point, remove
the journey hint from the '/success' headless-rp end point so it can be used for the
eIDAS smoke tests
- Add test to ensure there are no journey hint in the headless-rp '/success' end point