### PR TITLE
HUB-193: Add option to select simple profile flow

### DIFF
--- a/src/main/resources/uk/gov/ida/rp/testrp/views/landingPage.jade
+++ b/src/main/resources/uk/gov/ida/rp/testrp/views/landingPage.jade
@@ -36,6 +36,10 @@ block content
         | Use ForceAuthn and no-cycle3 test RP?
 
       p
+        input#not-signed-by-hub-rp(type="radio", name="rp-name-radio", value="test-rp-not-signed-by-hub", onclick='setRpName(this)')
+        | Use Simpleflow, not signed by hub test RP?
+
+      p
         input#non-eidas-rp(type="radio", name="rp-name-radio", value="test-rp-non-eidas", onclick='setRpName(this)')
         | Use non eidas test RP?
 


### PR DESCRIPTION
Add option to select simple profile flow with no cycle 3 that will be
unsigned by hub to simulate RPs using Shibboleth and allow for testing.

solo: @rachelthecodesmith