### PR TITLE
FIREBREAK: Rename test-rp

### DIFF
--- a/src/integration-test/java/uk/gov/ida/integrationTest/TestRpEidasJourneyDisabledAppRuleTest.java
+++ b/src/integration-test/java/uk/gov/ida/integrationTest/TestRpEidasJourneyDisabledAppRuleTest.java
@@ -47,7 +47,7 @@ public class TestRpEidasJourneyDisabledAppRuleTest extends IntegrationTestHelper
 
         assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
         String html = response.readEntity(String.class);
-        assertTrue(html.contains("Register for an identity profile"));
+        assertTrue(html.contains("Test GOV.UK Verify user journeys"));
         assertFalse(html.contains("Start with your European eID</button>"));
     }
 }

--- a/src/integration-test/java/uk/gov/ida/integrationTest/TestRpNoUserAccessControlPrivateBetaFalseAppRuleTests.java
+++ b/src/integration-test/java/uk/gov/ida/integrationTest/TestRpNoUserAccessControlPrivateBetaFalseAppRuleTests.java
@@ -60,7 +60,7 @@ public class TestRpNoUserAccessControlPrivateBetaFalseAppRuleTests extends Integ
                 .get(Response.class);
 
         assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
-        assertThat(response.readEntity(String.class)).contains("Register for an identity profile");
+        assertThat(response.readEntity(String.class)).contains("Test GOV.UK Verify user journeys");
     }
 
     @Test
@@ -74,7 +74,7 @@ public class TestRpNoUserAccessControlPrivateBetaFalseAppRuleTests extends Integ
                 .get(Response.class);
 
         assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
-        assertThat(response.readEntity(String.class)).contains("Register for an identity profile");
+        assertThat(response.readEntity(String.class)).contains("Test GOV.UK Verify user journeys");
     }
 
     @Test
@@ -86,6 +86,6 @@ public class TestRpNoUserAccessControlPrivateBetaFalseAppRuleTests extends Integ
                 .get(Response.class);
 
         assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
-        assertThat(response.readEntity(String.class)).contains("Register for an identity profile");
+        assertThat(response.readEntity(String.class)).contains("Test GOV.UK Verify user journeys");
     }
 }

--- a/src/integration-test/java/uk/gov/ida/integrationTest/TestRpNoUserAccessControlPrivateBetaTrueAppRuleTests.java
+++ b/src/integration-test/java/uk/gov/ida/integrationTest/TestRpNoUserAccessControlPrivateBetaTrueAppRuleTests.java
@@ -61,7 +61,7 @@ public class TestRpNoUserAccessControlPrivateBetaTrueAppRuleTests extends Integr
                 .get(Response.class);
 
         assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
-        assertThat(response.readEntity(String.class)).contains("Register for an identity profile");
+        assertThat(response.readEntity(String.class)).contains("Test GOV.UK Verify user journeys");
     }
 
     @Test

--- a/src/integration-test/java/uk/gov/ida/integrationTest/TestRpUserAccessControlledAppRuleTests.java
+++ b/src/integration-test/java/uk/gov/ida/integrationTest/TestRpUserAccessControlledAppRuleTests.java
@@ -93,7 +93,7 @@ public class TestRpUserAccessControlledAppRuleTests extends IntegrationTestHelpe
         assertThat(response.getCookies().values()).contains(new NewCookie(ACCESS_TOKEN_COOKIE_NAME, AUTHORIZED_TOKEN_VALUE));
         response = requestedLandingPageWithCookieValue();
         assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
-        assertThat(response.readEntity(String.class)).contains("Register for an identity profile");
+        assertThat(response.readEntity(String.class)).contains("Test GOV.UK Verify user journeys");
     }
 
     private Response requestedLandingPageWithCookieValue() {

--- a/src/main/resources/uk/gov/ida/rp/testrp/views/landingPage.jade
+++ b/src/main/resources/uk/gov/ida/rp/testrp/views/landingPage.jade
@@ -1,50 +1,64 @@
 extends layout/layout
 
 block vars
-  - pageTitle = "Register for an identity profile - GOV.UK"
+  - pageTitle = "Test GOV.UK Verify user journeys - GOV.UK"
   - bodyClass = "home"
   - showRelatedContent = true
 
 block h1
-  | Register for an identity profile
+  | Test GOV.UK Verify user journeys
 
 block content
   article(role="article")
     .summary
-      p This is a service to test registration to the Identity Assurance Programme. This service has been set up to allow certified companies to trial their customer registration and sign-in process.
-    h2 Before you start
-    p You should know that:
+      p This service allows you to test different GOV.UK Verify user journeys. Throughout the journey being tested, this service will stand in for a government service that uses GOV.UK Verify.
+    p You can use this service to test the following user journeys: 
     ul
-      li you will be creating a real identity profile with a certified company.
-      li the identity profile you create can be used to access government services online once they start to use the Identity Assurance service.
-      li to create your identity profile you will need to verify your identity online with a certified company.
+      li creating a new identity account with an identity provider
+      li single IDP journey (creating an identity account following a prompt by a specific identity provider)
+      li signing in with an existing identity account
+      li pausing the verification process and continuing it later
+    h2 Before you start
+    p 
+      = "This page represents the start page of a "
+      a(href="https://www.gov.uk/government/publications/introducing-govuk-verify/introducing-govuk-verify#government-services") government service that uses GOV.UK Verify 
+      |  - this is how users start the process of verifying their identity with an identity provider.
+    p This is a test environment - you cannot use this service to create a real identity account.
+    h2 Additional options
+    p Use these options to change the user journey this service will test.
+    p You can use this service to test a journey that:
     form(action='/test-rp/success', method='get')
       p
         input.no-match(type="checkbox", name="no-match")
-        | Should not match user? (user account creation)
+        | does not match a user against an existing database (creates an account)
 
       p
         input.fail-account-creation(type="checkbox", name="fail-account-creation")
-        | Should fail account creation?
-
+        | fails to create a user account
+      br
+      p You can also use it to test a journey with a service that:
       p
         input#loa1-rp(type="radio", name="rp-name-radio", value="loa1-test-rp", onclick='setRpName(this)')
-        | Use LoA1 test RP?
+        | accepts identities to LOA 1 (by default, this service will test LOA 2 journeys)
 
       p
         input#forceauthn-noc3-rp(type="radio", name="rp-name-radio", value="test-rp-noc3", onclick='setRpName(this)')
-        | Use ForceAuthn and no-cycle3 test RP?
+        | uses ForceAuthn and no cycle3
 
       p
         input#not-signed-by-hub-rp(type="radio", name="rp-name-radio", value="test-rp-not-signed-by-hub", onclick='setRpName(this)')
-        | Use Simpleflow, not signed by hub test RP?
+        | uses Simpleflow (Shibboleth), not signed by hub
 
       p
         input#non-eidas-rp(type="radio", name="rp-name-radio", value="test-rp-non-eidas", onclick='setRpName(this)')
-        | Use non eidas test RP?
+        | is not set up to use eIDAS
 
       p
-        label(for="journey_hint") Journey hint:
+        label(for="rp-name") Overridden RP Name
+        input#rp-name(type="textbox", name="rp-name")
+      h3 Journey hint
+      p This tells GOV.UK Verify about the user journey. Choosing one of the options will trigger a specific type of user journey.
+      p
         select(name="journey_hint")
           option(value="none", selected="true") None
           option(value="submission_confirmation") Non-repudiation
@@ -53,10 +67,7 @@ block content
           option(value="uk_idp_start") Start Sign in with GOV.UK Verify
           option(value="eidas_sign_in") Sign-in with eIDAS
           option(value="unspecified") Unspecified
-
-      p
-        label(for="rp-name") Overridden RP Name
-        input#rp-name(type="textbox", name="rp-name")
+      
       p
         input.button.get-started(type="submit", value="Start")
 

--- a/startup.sh
+++ b/startup.sh
@@ -6,7 +6,7 @@ if test -e local.env; then
     set +a
 else
     printf "$(tput setaf 1)No local environment found. Use verify-local-startup or openssl to generate a local.env file\n$(tput sgr0)"
-    echo "verify-local-startup$ ruby generate-env.rb -f ../ida-sample-rp/local.env"
+    echo "verify-local-startup$ ruby generate-env.rb -f ../verify-test-rp/local.env"
     exit
 fi
 


### PR DESCRIPTION
Renaming test-rp name "register for an identity" profile to "test GOV.UK Verify user journeys"
to make the content more readable.