### PR TITLE
Add security and no-cache headers

### DIFF
--- a/src/integration-test/java/uk/gov/ida/integrationTest/SecurityHeadersIntegrationTests.java
+++ b/src/integration-test/java/uk/gov/ida/integrationTest/SecurityHeadersIntegrationTests.java
@@ -1,0 +1,41 @@
+package uk.gov.ida.integrationTest;
+
+import io.dropwizard.testing.ConfigOverride;
+import io.dropwizard.testing.ResourceHelpers;
+import org.glassfish.jersey.client.ClientProperties;
+import org.glassfish.jersey.client.JerseyClientBuilder;
+import org.junit.ClassRule;
+import org.junit.Test;
+import uk.gov.ida.integrationTest.support.IntegrationTestHelper;
+import uk.gov.ida.integrationTest.support.TestRpAppRule;
+import uk.gov.ida.rp.testrp.filters.SecurityHeadersFilterTest;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SecurityHeadersIntegrationTests extends IntegrationTestHelper {
+
+    private final Client client = JerseyClientBuilder.createClient().property(ClientProperties.FOLLOW_REDIRECTS, false);
+
+    @ClassRule
+    public static final TestRpAppRule applicationRule = TestRpAppRule.newTestRpAppRule(
+            ConfigOverride.config("clientTrustStoreConfiguration.path", ResourceHelpers.resourceFilePath("ida_truststore.ts")),
+            ConfigOverride.config("msaMetadataUri", "http://localhost:"+getMsaStubRule().getPort()+"/metadata"),
+            ConfigOverride.config("allowInsecureMetadataLocation", "true"));
+
+    @Test
+    public void securityHeaderTest() {
+        final Response response = client.target(UriBuilder.fromUri("http://localhost:" + applicationRule.getLocalPort())
+                .path("/page_does_not_exist")
+                .build())
+                .request()
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(404);
+        SecurityHeadersFilterTest.checkSecurityHeaders(response.getHeaders());
+    }
+
+}

--- a/src/main/java/uk/gov/ida/rp/testrp/TestRpApplication.java
+++ b/src/main/java/uk/gov/ida/rp/testrp/TestRpApplication.java
@@ -21,7 +21,9 @@ import uk.gov.ida.filters.AcceptLanguageFilter;
 import uk.gov.ida.rp.testrp.authentication.TestRpAuthProvider;
 import uk.gov.ida.rp.testrp.exceptions.InvalidAccessTokenExceptionMapper;
 import uk.gov.ida.rp.testrp.exceptions.TokenServiceUnavailableExceptionMapper;
+import uk.gov.ida.rp.testrp.filters.NoCacheResponseFilter;
 import uk.gov.ida.rp.testrp.filters.SampleRpCacheControlFilter;
+import uk.gov.ida.rp.testrp.filters.SecurityHeadersFilter;
 import uk.gov.ida.rp.testrp.resources.AuthnResponseReceiverResource;
 import uk.gov.ida.rp.testrp.resources.CookiesInfoResource;
 import uk.gov.ida.rp.testrp.resources.HeadlessRpResource;
@@ -115,6 +117,10 @@ public class TestRpApplication extends Application<TestRpConfiguration> {
         //exception mappers
         environment.jersey().register(InvalidAccessTokenExceptionMapper.class);
         environment.jersey().register(TokenServiceUnavailableExceptionMapper.class);
+
+        //filters
+        environment.jersey().register(NoCacheResponseFilter.class);
+        environment.jersey().register(SecurityHeadersFilter.class);
 
         //health checks
         environment.healthChecks().register("metadata", guiceBundle.getInjector().getInstance(MetadataHealthCheck.class));

--- a/src/main/java/uk/gov/ida/rp/testrp/filters/NoCacheResponseFilter.java
+++ b/src/main/java/uk/gov/ida/rp/testrp/filters/NoCacheResponseFilter.java
@@ -1,0 +1,24 @@
+package uk.gov.ida.rp.testrp.filters;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.core.MediaType;
+
+import static uk.gov.ida.common.HttpHeaders.CACHE_CONTROL_KEY;
+import static uk.gov.ida.common.HttpHeaders.CACHE_CONTROL_NO_CACHE_VALUE;
+import static uk.gov.ida.common.HttpHeaders.PRAGMA_KEY;
+import static uk.gov.ida.common.HttpHeaders.PRAGMA_NO_CACHE_VALUE;
+
+public class NoCacheResponseFilter implements ContainerResponseFilter {
+    @Override
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) {
+        final MediaType responseContextMediaType = responseContext.getMediaType();
+
+        if(MediaType.TEXT_HTML_TYPE.isCompatible(responseContextMediaType)
+                || MediaType.APPLICATION_JSON_TYPE.isCompatible(responseContextMediaType)) {
+            responseContext.getHeaders().add(CACHE_CONTROL_KEY, CACHE_CONTROL_NO_CACHE_VALUE);
+            responseContext.getHeaders().add(PRAGMA_KEY, PRAGMA_NO_CACHE_VALUE);
+        }
+    }
+}

--- a/src/main/java/uk/gov/ida/rp/testrp/filters/SecurityHeadersFilter.java
+++ b/src/main/java/uk/gov/ida/rp/testrp/filters/SecurityHeadersFilter.java
@@ -1,0 +1,22 @@
+package uk.gov.ida.rp.testrp.filters;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import java.io.IOException;
+
+public class SecurityHeadersFilter implements ContainerResponseFilter {
+    @Override
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) throws IOException {
+        responseContext.getHeaders().add("X-Frame-Options", "DENY");
+        responseContext.getHeaders().add("X-XSS-Protection", "1; mode=block");
+        responseContext.getHeaders().add("X-Content-Type-Options", "nosniff");
+        final String contentSecurityPolicy = "default-src 'self'; " +
+                "font-src data:; " +
+                "img-src 'self'; " +
+                "object-src 'none'; " +
+                "style-src 'self' 'unsafe-inline'; " +
+                "script-src 'self';";
+        responseContext.getHeaders().add("Content-Security-Policy", contentSecurityPolicy);
+    }
+}

--- a/src/main/resources/assets/scripts/js-enabled.js
+++ b/src/main/resources/assets/scripts/js-enabled.js
@@ -1,0 +1,1 @@
+document.documentElement.className = ((document.documentElement.className) ? document.documentElement.className + ' js-enabled' : 'js-enabled');

--- a/src/main/resources/assets/scripts/saml-redirect-auto-submit.js
+++ b/src/main/resources/assets/scripts/saml-redirect-auto-submit.js
@@ -8,4 +8,4 @@ function initAutoSubmitSequence() {
     document.forms[0].submit();
 }
 
-document.addEventListener('load', initAutoSubmitSequence());
+document.addEventListener('load', initAutoSubmitSequence);

--- a/src/main/resources/assets/scripts/saml-redirect-auto-submit.js
+++ b/src/main/resources/assets/scripts/saml-redirect-auto-submit.js
@@ -1,0 +1,11 @@
+function initAutoSubmitSequence() {
+    document.forms[0].setAttribute("style", "display: none;");
+
+    window.setTimeout(function () {
+        document.forms[0].removeAttribute("style");
+    }, 5000);
+
+    document.forms[0].submit();
+}
+
+document.addEventListener('load', initAutoSubmitSequence());

--- a/src/main/resources/assets/scripts/set-rp-name.js
+++ b/src/main/resources/assets/scripts/set-rp-name.js
@@ -1,4 +1,5 @@
-function setRpName(element) {
+function setRpName(event) {
+  element = event.target
   if (element.checked) {
     document.getElementById("rp-name").value = element.value
   } else {
@@ -6,7 +7,7 @@ function setRpName(element) {
   }
 }
 
-document.getElementById('loa1-rp').addEventListener('click', setRpName(this));
-document.getElementById('forceauthn-noc3-rp').addEventListener('click', setRpName(this));
-document.getElementById('not-signed-by-hub-rp').addEventListener('click', setRpName(this));
-document.getElementById('non-eidas-rp').addEventListener('click', setRpName(this));
+document.getElementById('loa1-rp').addEventListener('click', setRpName);
+document.getElementById('forceauthn-noc3-rp').addEventListener('click', setRpName);
+document.getElementById('not-signed-by-hub-rp').addEventListener('click', setRpName);
+document.getElementById('non-eidas-rp').addEventListener('click', setRpName);

--- a/src/main/resources/assets/scripts/set-rp-name.js
+++ b/src/main/resources/assets/scripts/set-rp-name.js
@@ -1,0 +1,12 @@
+function setRpName(element) {
+  if (element.checked) {
+    document.getElementById("rp-name").value = element.value
+  } else {
+    document.getElementById("rp-name").value = ''
+  }
+}
+
+document.getElementById('loa1-rp').addEventListener('click', setRpName(this));
+document.getElementById('forceauthn-noc3-rp').addEventListener('click', setRpName(this));
+document.getElementById('not-signed-by-hub-rp').addEventListener('click', setRpName(this));
+document.getElementById('non-eidas-rp').addEventListener('click', setRpName(this));

--- a/src/main/resources/uk/gov/ida/rp/testrp/views/landingPage.jade
+++ b/src/main/resources/uk/gov/ida/rp/testrp/views/landingPage.jade
@@ -38,19 +38,19 @@ block content
       br
       p You can also use it to test a journey with a service that:
       p
-        input#loa1-rp(type="radio", name="rp-name-radio", value="loa1-test-rp", onclick='setRpName(this)')
+        input#loa1-rp(type="radio", name="rp-name-radio", value="loa1-test-rp")
         | accepts identities to LOA 1 (by default, this service will test LOA 2 journeys)
 
       p
-        input#forceauthn-noc3-rp(type="radio", name="rp-name-radio", value="test-rp-noc3", onclick='setRpName(this)')
+        input#forceauthn-noc3-rp(type="radio", name="rp-name-radio", value="test-rp-noc3")
         | uses ForceAuthn and no cycle3
 
       p
-        input#not-signed-by-hub-rp(type="radio", name="rp-name-radio", value="test-rp-not-signed-by-hub", onclick='setRpName(this)')
+        input#not-signed-by-hub-rp(type="radio", name="rp-name-radio", value="test-rp-not-signed-by-hub")
         | uses Simpleflow (Shibboleth), not signed by hub
 
       p
-        input#non-eidas-rp(type="radio", name="rp-name-radio", value="test-rp-non-eidas", onclick='setRpName(this)')
+        input#non-eidas-rp(type="radio", name="rp-name-radio", value="test-rp-non-eidas")
         | is not set up to use eIDAS
 
       p
@@ -71,14 +71,7 @@ block content
       p
         input.button.get-started(type="submit", value="Start")
 
-  script.
-    function setRpName(element) {
-      if (element.checked) {
-        document.getElementById("rp-name").value = element.value
-      } else {
-        document.getElementById("rp-name").value = ''
-      }
-    }
+  script(src='/assets/scripts/set-rp-name.js')
 
 block relatedContent
   h2 More about identity assurance

--- a/src/main/resources/uk/gov/ida/rp/testrp/views/layout/layout.jade
+++ b/src/main/resources/uk/gov/ida/rp/testrp/views/layout/layout.jade
@@ -10,8 +10,6 @@ html(lang="en")
   head
     meta(http-equiv="content-type", content="text/html; charset=UTF-8")
     title=pageTitle
-    script.
-      (function(){if(navigator.userAgent.match(/IEMobile\/10\.0/)){var d=document,c="appendChild",a=d.createElement("style");a[c](d.createTextNode("@-ms-viewport{width:auto!important}"));d.getElementsByTagName("head")[0][c](a);}})();
 
     +stylesheetLinkTag("govuk-template","screen")
     +stylesheetLinkTag("ida-sample-rp","screen")
@@ -31,8 +29,7 @@ html(lang="en")
     block headerScripts
   body(class="#{bodyClass}")
 
-    script.
-      document.documentElement.className = ((document.documentElement.className) ? document.documentElement.className + ' js-enabled' : 'js-enabled');
+    script(src='/assets/scripts/js-enabled.js')
 
     #skiplink-container
       div

--- a/src/main/resources/uk/gov/ida/rp/testrp/views/samlRedirectView.ftl
+++ b/src/main/resources/uk/gov/ida/rp/testrp/views/samlRedirectView.ftl
@@ -3,6 +3,7 @@
 <html>
 <head>
     <title>Saml Processing...</title>
+    <script type="text/javascript" src="/assets/scripts/saml-redirect-auto-submit.js" defer="true"></script>
     <style type='text/css'>
       body {
         padding-top: 2em;
@@ -39,5 +40,4 @@
     <button class='verify-button' id="continue-button">Continue</button>
 </form>
 </body>
-<script type="text/javascript" src="/assets/scripts/saml-redirect-auto-submit.js"></script>
 </html>

--- a/src/main/resources/uk/gov/ida/rp/testrp/views/samlRedirectView.ftl
+++ b/src/main/resources/uk/gov/ida/rp/testrp/views/samlRedirectView.ftl
@@ -3,17 +3,6 @@
 <html>
 <head>
     <title>Saml Processing...</title>
-    <script type="text/javascript">
-        function init() {
-            document.forms[0].setAttribute("style", "display: none;");
-
-            window.setTimeout(function () {
-                document.forms[0].removeAttribute("style");
-            }, 5000);
-
-            document.forms[0].submit();
-        }
-    </script>
     <style type='text/css'>
       body {
         padding-top: 2em;
@@ -38,7 +27,7 @@
       }
     </style>
 </head>
-<body onload="init()">
+<body>
 <form class='verify-saml-form' action="${targetUri}" method="POST">
        <h1>Continue to next step</h1>
        <p>Because Javascript is not enabled on your browser, you must press the continue button</p>
@@ -50,4 +39,5 @@
     <button class='verify-button' id="continue-button">Continue</button>
 </form>
 </body>
+<script type="text/javascript" src="/assets/scripts/saml-redirect-auto-submit.js"></script>
 </html>

--- a/src/test/java/uk/gov/ida/rp/testrp/filters/SecurityHeadersFilterTest.java
+++ b/src/test/java/uk/gov/ida/rp/testrp/filters/SecurityHeadersFilterTest.java
@@ -1,0 +1,53 @@
+package uk.gov.ida.rp.testrp.filters;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SecurityHeadersFilterTest {
+
+    @Mock
+    private ContainerRequestContext containerRequestContext;
+
+    @Mock
+    private ContainerResponseContext containerResponseContext;
+
+    @Test
+    public void checkSecurityHeadersAreAdded() throws IOException {
+        SecurityHeadersFilter securityHeadersFilter = new SecurityHeadersFilter();
+        MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
+        when(containerResponseContext.getHeaders()).thenReturn(headers);
+
+        securityHeadersFilter.filter(containerRequestContext, containerResponseContext);
+
+        assertThat(headers.keySet().size()).isEqualTo(4);
+        checkSecurityHeaders(headers);
+    }
+
+    public static void checkSecurityHeaders(MultivaluedMap<String, Object> headers) {
+        assertThat(headers.containsKey("X-Frame-Options")).isTrue();
+        assertThat(headers.get("X-Frame-Options").size()).isEqualTo(1);
+        assertThat(headers.get("X-Frame-Options").get(0)).isEqualTo("DENY");
+        assertThat(headers.containsKey("X-XSS-Protection")).isTrue();
+        assertThat(headers.get("X-XSS-Protection").size()).isEqualTo(1);
+        assertThat(headers.get("X-XSS-Protection").get(0)).isEqualTo("1; mode=block");
+        assertThat(headers.containsKey("X-Content-Type-Options")).isTrue();
+        assertThat(headers.get("X-Content-Type-Options").get(0)).isEqualTo("nosniff");
+        assertThat(headers.get("X-Content-Type-Options").size()).isEqualTo(1);
+        assertThat(headers.containsKey("Content-Security-Policy")).isTrue();
+        assertThat(headers.get("Content-Security-Policy").size()).isEqualTo(1);
+        assertThat(headers.get("Content-Security-Policy").get(0)).isEqualTo("default-src 'self'; font-src data:; img-src 'self'; object-src 'none'; style-src 'self' 'unsafe-inline'; script-src 'self';");
+    }
+
+}


### PR DESCRIPTION
Essentially the same as https://github.com/alphagov/verify-stub-idp/pull/55 as well as adding in the no-cache headers for json (local matching service) and html (mainly for the user account creation attributes)

Tested locally, working fine