### PR TITLE
EID-1211 - Explicitly set TLSv1.2 in the MetadataResolverProviderTest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ jdk:
   - openjdk10
   - openjdk11
 matrix:
-  allow_failures:
-  - jdk: openjdk11
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/

--- a/src/test/java/uk/gov/ida/rp/testrp/metadata/MetadataResolverProviderTest.java
+++ b/src/test/java/uk/gov/ida/rp/testrp/metadata/MetadataResolverProviderTest.java
@@ -6,6 +6,7 @@ import net.shibboleth.utilities.java.support.resolver.CriteriaSet;
 import org.apache.commons.io.FileUtils;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -42,9 +43,14 @@ public class MetadataResolverProviderTest {
     }
 
     @Mock
-    TestRpConfiguration configuration;
+    private TestRpConfiguration configuration;
 
     private static Client client = ClientBuilder.newBuilder().hostnameVerifier(new NoopHostnameVerifier()).trustStore(createKeyStore()).build();
+
+    @Before
+    public void setUp() {
+        System.setProperty("https.protocols", "TLSv1.2");
+    }
 
     @Test
     public void shouldPerformHttpsRequestWhenInsecureMetadataFlagIsNotPresent() throws Exception {


### PR DESCRIPTION
- By default java11 uses TLSv1.3, this causes the MetadataResolverProviderTest
to fail due to the supported_groups extension being rejected in ServerHellos.
JDK11 currently throws an exception if this extension is sent in the ServerHello handshake message.
- This extension been allowed in previous versions of Java and will also be enabled
when the next jdk11 patch has been released. https://bugs.openjdk.java.net/browse/JDK-8210005