### PR TITLE
HUB-50 upgrade to dropwizard 1.38

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,8 +52,8 @@ ext {
 
 def dependencyVersions = [
         ida_utils:336,
-        dropwizard:'1.2.0',
-        dropwizard_jade:10516,
+        dropwizard:'1.3.8',
+        dropwizard_jade:10517,
         ida_test_utils: '2.0.0-43',
         ida_dev_pki: '1.1.0-43',
         opensaml_version: "$opensaml",
@@ -113,7 +113,7 @@ dependencies {
             'uk.gov.ida:rest-utils:2.0.0-' + dependencyVersions.ida_utils,
             'uk.gov.ida:security-utils:2.0.0-' + dependencyVersions.ida_utils
 
-    jade 'uk.gov.ida:dropwizard-jade:1.1.4-' + dependencyVersions.dropwizard_jade
+    jade 'uk.gov.ida:dropwizard-jade:1.3.8-' + dependencyVersions.dropwizard_jade
 
     ida_test_utils 'uk.gov.ida:common-test-utils:' + dependencyVersions.ida_test_utils
 

--- a/src/main/java/uk/gov/ida/rp/testrp/TestRpApplication.java
+++ b/src/main/java/uk/gov/ida/rp/testrp/TestRpApplication.java
@@ -78,7 +78,7 @@ public class TestRpApplication extends Application<TestRpConfiguration> {
             @Override
             public Map<String, Map<String, String>> getViewConfiguration(TestRpConfiguration config) {
                 // beware: this is to force enable escaping of unsanitised user input
-                return ImmutableMap.of(new FreemarkerViewRenderer().getSuffix(),
+                return ImmutableMap.of(new FreemarkerViewRenderer().getConfigurationKey(),
                         ImmutableMap.of(
                                 "output_format", "HTMLOutputFormat"
                         ));


### PR DESCRIPTION
Change version for dropwizard to 1.38.  Use build 10517 of dropwizard-jade which has been upgraded to dropwizard 1.3.8 also.