### PR TITLE
TfEzFc4W: Implement cross domain google analytics tracking for verify - 2nd Line

### DIFF
--- a/configuration/local/test-rp.yml
+++ b/configuration/local/test-rp.yml
@@ -90,3 +90,5 @@ imagesPath: /assets/images
 privateBetaUserAccessRestrictionEnabled: ${TEST_RP_PRIVATE_BETA_USER_ACCESS_RESTRICTION_ENABLED:-false}
 
 shouldShowStartWithEidasButton: ${TEST_RP_SHOULD_SHOW_START_WITH_EIDAS_BUTTON:-true}
+
+crossGovGaTrackerId: ${CROSS_GOV_GA_TRACKER_ID:-UA-XXXXX-Y}

--- a/configuration/test-rp.yml
+++ b/configuration/test-rp.yml
@@ -75,3 +75,5 @@ imagesPath: /assets/images
 privateBetaUserAccessRestrictionEnabled: ${PRIVATE_BETA_USER_ACCESS_RESTRICTION_ENABLED}
 
 shouldShowStartWithEidasButton: ${SHOULD_SHOW_START_WITH_EIDAS_BUTTON}
+
+crossGovGaTrackerId: ${CROSS_GOV_GA_TRACKER_ID:-UA-XXXXX-Y}

--- a/src/main/java/uk/gov/ida/rp/testrp/TestRpConfiguration.java
+++ b/src/main/java/uk/gov/ida/rp/testrp/TestRpConfiguration.java
@@ -133,6 +133,10 @@ public class TestRpConfiguration extends Configuration implements AssetCacheConf
     @JsonProperty
     protected int tokenEpoch = 1;
 
+    @JsonProperty
+    protected String crossGovGaTrackerId = "";
+
+
     protected TestRpConfiguration() {}
 
     public String getHubEntityId() {
@@ -226,6 +230,10 @@ public class TestRpConfiguration extends Configuration implements AssetCacheConf
 
     public int getTokenEpoch() {
         return tokenEpoch;
+    }
+
+    public String getCrossGovGaTrackerId() {
+        return crossGovGaTrackerId;
     }
 
 }

--- a/src/main/java/uk/gov/ida/rp/testrp/Urls.java
+++ b/src/main/java/uk/gov/ida/rp/testrp/Urls.java
@@ -50,6 +50,8 @@ public interface Urls {
         String EIDAS_PARAM = "eidas";
         String NO_MATCH = "no-match";
         String FAIL_ACCOUNT_CREATION = "fail-account-creation";
+
+        String GA_CLIENT_ID = "_ga";
     }
 
 }

--- a/src/main/java/uk/gov/ida/rp/testrp/exceptions/InvalidAccessTokenExceptionMapper.java
+++ b/src/main/java/uk/gov/ida/rp/testrp/exceptions/InvalidAccessTokenExceptionMapper.java
@@ -30,6 +30,6 @@ public class InvalidAccessTokenExceptionMapper implements ExceptionMapper<Invali
         UUID eventId = UUID.randomUUID();
         LOG.error(MessageFormat.format("{0} - Exception while processing request.", eventId), exception);
 
-        return Response.status(Response.Status.FORBIDDEN).entity(new TestRpPrivateBetaPageView(configuration.getJavascriptPath(), configuration.getStylesheetsPath(), configuration.getImagesPath())).build();
+        return Response.status(Response.Status.FORBIDDEN).entity(new TestRpPrivateBetaPageView(configuration.getJavascriptPath(), configuration.getStylesheetsPath(), configuration.getImagesPath(), configuration.getCrossGovGaTrackerId())).build();
     }
 }

--- a/src/main/java/uk/gov/ida/rp/testrp/exceptions/TokenServiceUnavailableExceptionMapper.java
+++ b/src/main/java/uk/gov/ida/rp/testrp/exceptions/TokenServiceUnavailableExceptionMapper.java
@@ -30,6 +30,6 @@ public class TokenServiceUnavailableExceptionMapper implements ExceptionMapper<T
         UUID eventId = UUID.randomUUID();
         LOG.error(MessageFormat.format("{0} - Exception while processing request.", eventId), exception);
 
-        return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(new TestRpTokenServiceUnavailablePageView(configuration.getJavascriptPath(), configuration.getStylesheetsPath(), configuration.getImagesPath())).build();
+        return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(new TestRpTokenServiceUnavailablePageView(configuration.getJavascriptPath(), configuration.getStylesheetsPath(), configuration.getImagesPath(), configuration.getCrossGovGaTrackerId())).build();
     }
 }

--- a/src/main/java/uk/gov/ida/rp/testrp/filters/SecurityHeadersFilter.java
+++ b/src/main/java/uk/gov/ida/rp/testrp/filters/SecurityHeadersFilter.java
@@ -13,10 +13,11 @@ public class SecurityHeadersFilter implements ContainerResponseFilter {
         responseContext.getHeaders().add("X-Content-Type-Options", "nosniff");
         final String contentSecurityPolicy = "default-src 'self'; " +
                 "font-src data:; " +
-                "img-src 'self'; " +
+                "img-src 'self' www.google-analytics.com; " +
                 "object-src 'none'; " +
                 "style-src 'self' 'unsafe-inline'; " +
-                "script-src 'self';";
+                "script-src 'self' www.google-analytics.com; " +
+                "connect-src 'self' www.google-analytics.com;";
         responseContext.getHeaders().add("Content-Security-Policy", contentSecurityPolicy);
     }
 }

--- a/src/main/java/uk/gov/ida/rp/testrp/resources/AuthnResponseReceiverResource.java
+++ b/src/main/java/uk/gov/ida/rp/testrp/resources/AuthnResponseReceiverResource.java
@@ -15,6 +15,7 @@ import javax.ws.rs.FormParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.NewCookie;
 import javax.ws.rs.core.Response;
@@ -47,13 +48,14 @@ public class AuthnResponseReceiverResource {
     @POST
     public Response doLogin(
             @FormParam(Urls.Params.SAML_RESPONSE_PARAM) @NotNull String samlResponse,
-            @FormParam(Urls.Params.RELAY_STATE_PARAM) SessionId relayState) {
+            @FormParam(Urls.Params.RELAY_STATE_PARAM) SessionId relayState,
+            @QueryParam(Urls.Params.GA_CLIENT_ID) String gaClientId) {
 
         ResponseFromHub responseFromHub = authnResponseReceiverHandler.handleResponse(samlResponse, Optional.ofNullable(relayState));
 
         switch (responseFromHub.getTransactionIdaStatus()){
             case Success:
-                return handleSuccess(responseFromHub);
+                return handleSuccess(responseFromHub, gaClientId);
             case NoMatchingServiceMatchFromHub:
             case NoAuthenticationContext:
             case AuthenticationFailed:
@@ -64,7 +66,7 @@ public class AuthnResponseReceiverResource {
         }
     }
 
-    private Response handleSuccess(ResponseFromHub responseFromHub) {
+    private Response handleSuccess(ResponseFromHub responseFromHub, String gaClientId) {
         if(responseFromHub.getAttributes().isEmpty()) {
             UriBuilder location = UriBuilder.fromPath(TEST_RP_ROOT);
             if (responseFromHub.getRedirectUri().isPresent()) {
@@ -72,6 +74,9 @@ public class AuthnResponseReceiverResource {
             }
             if (responseFromHub.getAuthnContext().isPresent()) {
                 location.queryParam(Urls.Params.LOA_PARAM, responseFromHub.getAuthnContext().get().name());
+            }
+            if (gaClientId != null && !gaClientId.isEmpty()) {
+                location.queryParam(Urls.Params.GA_CLIENT_ID, gaClientId);
             }
             final Response.ResponseBuilder responseBuilder = Response.seeOther(location.build());
             if(responseFromHub.getSessionId().isPresent()) {

--- a/src/main/java/uk/gov/ida/rp/testrp/resources/AuthnResponseReceiverResource.java
+++ b/src/main/java/uk/gov/ida/rp/testrp/resources/AuthnResponseReceiverResource.java
@@ -1,5 +1,6 @@
 package uk.gov.ida.rp.testrp.resources;
 
+import org.apache.http.client.utils.URIBuilder;
 import uk.gov.ida.common.SessionId;
 import uk.gov.ida.rp.testrp.TestRpConfiguration;
 import uk.gov.ida.rp.testrp.Urls;
@@ -60,7 +61,7 @@ public class AuthnResponseReceiverResource {
             case NoAuthenticationContext:
             case AuthenticationFailed:
             case RequesterError:
-                return errorResponse(responseFromHub.getTransactionIdaStatus());
+                return errorResponse(responseFromHub.getTransactionIdaStatus(), gaClientId);
             default:
                 throw new IllegalStateException(format("Unexpected status in hub response. {0}", responseFromHub));
         }
@@ -93,10 +94,11 @@ public class AuthnResponseReceiverResource {
         }
     }
 
-    private Response errorResponse(TransactionIdaStatus transactionIdaStatus) {
-        URI location = fromResource(TestRpResource.class)
-                .queryParam(Urls.Params.ERROR_CODE_PARAM, transactionIdaStatus)
-                .build();
+    private Response errorResponse(TransactionIdaStatus transactionIdaStatus, String gaClientId) {
+        UriBuilder builder = fromResource(TestRpResource.class)
+                .queryParam(Urls.Params.ERROR_CODE_PARAM, transactionIdaStatus);
+        if ( gaClientId != null && !gaClientId.isEmpty() ) builder.queryParam(Urls.Params.GA_CLIENT_ID, gaClientId);
+        URI location = builder.build();
         return Response.seeOther(location).build();
     }
 

--- a/src/main/java/uk/gov/ida/rp/testrp/resources/AuthnResponseReceiverResource.java
+++ b/src/main/java/uk/gov/ida/rp/testrp/resources/AuthnResponseReceiverResource.java
@@ -86,7 +86,7 @@ public class AuthnResponseReceiverResource {
 
         } else {
             // user account creation
-            final TestRpUserAccountCreatedView testRpUserAccountCreatedView = new TestRpUserAccountCreatedView(testRpConfiguration.getJavascriptPath(), testRpConfiguration.getStylesheetsPath(), testRpConfiguration.getImagesPath(), responseFromHub.getSession().get(), responseFromHub.getAttributes(), responseFromHub.getAuthnContext().get().name());
+            final TestRpUserAccountCreatedView testRpUserAccountCreatedView = new TestRpUserAccountCreatedView(testRpConfiguration.getJavascriptPath(), testRpConfiguration.getStylesheetsPath(), testRpConfiguration.getImagesPath(), responseFromHub.getSession().get(), responseFromHub.getAttributes(), responseFromHub.getAuthnContext().get().name(), testRpConfiguration.getCrossGovGaTrackerId());
             return Response.ok(testRpUserAccountCreatedView)
                     .cookie(new NewCookie(TEST_RP_SESSION_COOKIE_NAME, responseFromHub.getSessionId().get().getSessionId()))
                     .build();

--- a/src/main/java/uk/gov/ida/rp/testrp/resources/CookiesInfoResource.java
+++ b/src/main/java/uk/gov/ida/rp/testrp/resources/CookiesInfoResource.java
@@ -23,7 +23,7 @@ public class CookiesInfoResource {
 
     @GET
     public CookiesInfoView getCookieInfo() {
-        return new CookiesInfoView(testRpConfiguration.getJavascriptPath(), testRpConfiguration.getStylesheetsPath(), testRpConfiguration.getImagesPath());
+        return new CookiesInfoView(testRpConfiguration.getJavascriptPath(), testRpConfiguration.getStylesheetsPath(), testRpConfiguration.getImagesPath(), testRpConfiguration.getCrossGovGaTrackerId());
     }
 
 }

--- a/src/main/java/uk/gov/ida/rp/testrp/resources/LocalMatchingServiceResource.java
+++ b/src/main/java/uk/gov/ida/rp/testrp/resources/LocalMatchingServiceResource.java
@@ -40,5 +40,4 @@ public class LocalMatchingServiceResource {
     public UnknownUserCreationResponseDto post(@NotNull UnknownUserCreationRequestDto request) {
         return matchingServiceRequestHandler.handleUserAccountCreationRequest(request);
     }
-
 }

--- a/src/main/java/uk/gov/ida/rp/testrp/resources/TestRpResource.java
+++ b/src/main/java/uk/gov/ida/rp/testrp/resources/TestRpResource.java
@@ -71,7 +71,7 @@ public class TestRpResource {
         tokenService.validate(token);
 
         final PageErrorMessageDetails errorMessageDetails = pageErrorMessageDetailsFactory.getErrorMessage(errorCode);
-        final TestRpLandingPageView testRpLandingPageView = new TestRpLandingPageView(configuration.getJavascriptPath(), configuration.getStylesheetsPath(), configuration.getImagesPath(), null, errorMessageDetails.getHeader(), errorMessageDetails.getMessage(), configuration.getShouldShowStartWithEidasButton());
+        final TestRpLandingPageView testRpLandingPageView = new TestRpLandingPageView(configuration.getJavascriptPath(), configuration.getStylesheetsPath(), configuration.getImagesPath(), null, errorMessageDetails.getHeader(), errorMessageDetails.getMessage(), configuration.getShouldShowStartWithEidasButton(), configuration.getCrossGovGaTrackerId());
 
         final Response.ResponseBuilder builder = Response
                 .status(Response.Status.OK)
@@ -90,7 +90,7 @@ public class TestRpResource {
             @QueryParam(Urls.Params.RP_NAME_PARAM) Optional<String> rpName,
             @QueryParam(Urls.Params.LOA_PARAM) Optional<LevelOfAssuranceDto> loa) {
         final PageErrorMessageDetails errorMessage = pageErrorMessageDetailsFactory.getErrorMessage(errorCode);
-        return new TestRpSuccessPageView(configuration.getJavascriptPath(), configuration.getStylesheetsPath(), configuration.getImagesPath(), session, errorMessage.getHeader(), errorMessage.getMessage(), rpName, loa);
+        return new TestRpSuccessPageView(configuration.getJavascriptPath(), configuration.getStylesheetsPath(), configuration.getImagesPath(), session, errorMessage.getHeader(), errorMessage.getMessage(), rpName, loa, configuration.getCrossGovGaTrackerId());
     }
 
     @POST

--- a/src/main/java/uk/gov/ida/rp/testrp/views/CookiesInfoView.java
+++ b/src/main/java/uk/gov/ida/rp/testrp/views/CookiesInfoView.java
@@ -8,8 +8,8 @@ public class CookiesInfoView extends TestRpView {
     private final Optional<String> errorHeader;
     private final Optional<String> errorMessage;
 
-    public CookiesInfoView(String javascriptBase, String stylesheetsBase, String imagesBase) {
-        super(javascriptBase, stylesheetsBase, imagesBase, null, "cookiesInfo.jade");
+    public CookiesInfoView(String javascriptBase, String stylesheetsBase, String imagesBase, String crossGovGaTrackerId) {
+        super(javascriptBase, stylesheetsBase, imagesBase, null, "cookiesInfo.jade", crossGovGaTrackerId);
         errorHeader = Optional.empty();
         errorMessage = Optional.empty();
     }

--- a/src/main/java/uk/gov/ida/rp/testrp/views/SamlAuthnRequestRedirectViewFactory.java
+++ b/src/main/java/uk/gov/ida/rp/testrp/views/SamlAuthnRequestRedirectViewFactory.java
@@ -2,6 +2,7 @@ package uk.gov.ida.rp.testrp.views;
 
 import com.google.common.net.HttpHeaders;
 import uk.gov.ida.common.SessionId;
+import uk.gov.ida.rp.testrp.TestRpConfiguration;
 import uk.gov.ida.rp.testrp.domain.JourneyHint;
 
 import javax.inject.Inject;
@@ -14,9 +15,11 @@ import java.util.Optional;
  */
 public class SamlAuthnRequestRedirectViewFactory {
 
+    private final TestRpConfiguration testRpConfiguration;
+
     @Inject
-    public SamlAuthnRequestRedirectViewFactory(){
-        // intentionally blank
+    public SamlAuthnRequestRedirectViewFactory(TestRpConfiguration testRpConfiguration){
+        this.testRpConfiguration = testRpConfiguration;
     }
 
     public Response sendSamlMessage(String messageToSend, SessionId relayState, URI targetUriFromSamlEndpoint, Optional<JourneyHint> journeyHint) {
@@ -29,7 +32,7 @@ public class SamlAuthnRequestRedirectViewFactory {
             URI targetUriFromSamlEndpoint,
             Optional<JourneyHint> journeyHint) {
 
-        SamlRedirectView samlFormPostingView = new SamlRedirectView(targetUriFromSamlEndpoint, samlMessage, relayState, journeyHint);
+        SamlRedirectView samlFormPostingView = new SamlRedirectView(targetUriFromSamlEndpoint, samlMessage, relayState, journeyHint, testRpConfiguration.getCrossGovGaTrackerId());
         return Response.ok(samlFormPostingView)
             .header(HttpHeaders.CACHE_CONTROL, "no-cache, no-store")
             .header(HttpHeaders.PRAGMA, "no-cache")

--- a/src/main/java/uk/gov/ida/rp/testrp/views/SamlRedirectView.java
+++ b/src/main/java/uk/gov/ida/rp/testrp/views/SamlRedirectView.java
@@ -12,16 +12,19 @@ public class SamlRedirectView extends View {
     private String responseBody;
     private SessionId relayState;
     private final Optional<JourneyHint> journeyHint;
+    private final String crossGovGaTrackerId;
 
     public SamlRedirectView(URI targetUri,
                             String base64EncodedResponseBody,
                             SessionId relayState,
-                            Optional<JourneyHint> journeyHint) {
+                            Optional<JourneyHint> journeyHint,
+                            String crossGovGaTrackerId) {
         super("samlRedirectView.ftl");
         this.targetUri = targetUri;
         this.responseBody = base64EncodedResponseBody;
         this.relayState = relayState;
         this.journeyHint = journeyHint;
+        this.crossGovGaTrackerId = crossGovGaTrackerId;
     }
 
     public URI getTargetUri() {
@@ -42,5 +45,9 @@ public class SamlRedirectView extends View {
 
     public String getJourneyHint() {
         return journeyHint.isPresent()?journeyHint.get().name():"";
+    }
+
+    public String getCrossGovGaTrackerId() {
+        return crossGovGaTrackerId;
     }
 }

--- a/src/main/java/uk/gov/ida/rp/testrp/views/TestRpLandingPageView.java
+++ b/src/main/java/uk/gov/ida/rp/testrp/views/TestRpLandingPageView.java
@@ -18,9 +18,10 @@ public class TestRpLandingPageView extends TestRpView {
             final Session session,
             final Optional<String> errorHeader,
             final Optional<String> errorMessage,
-            boolean shouldShowStartWithEidasButton) {
+            boolean shouldShowStartWithEidasButton,
+            String crossGovGaTrackerId) {
 
-        super(javascriptBase, stylesheetsBase, imagesBase, session, "landingPage.jade");
+        super(javascriptBase, stylesheetsBase, imagesBase, session, "landingPage.jade", crossGovGaTrackerId);
 
         this.errorHeader = errorHeader;
         this.errorMessage = errorMessage;

--- a/src/main/java/uk/gov/ida/rp/testrp/views/TestRpPrivateBetaPageView.java
+++ b/src/main/java/uk/gov/ida/rp/testrp/views/TestRpPrivateBetaPageView.java
@@ -8,8 +8,8 @@ public class TestRpPrivateBetaPageView extends TestRpView {
     private final Optional<String> errorHeader;
     private final Optional<String> errorMessage;
 
-    public TestRpPrivateBetaPageView(String javascriptBase, String stylesheetsBase, String imagesBase) {
-        super(javascriptBase, stylesheetsBase, imagesBase, null, "privateBetaPage.jade");
+    public TestRpPrivateBetaPageView(String javascriptBase, String stylesheetsBase, String imagesBase, String crossGovGaTrackerId) {
+        super(javascriptBase, stylesheetsBase, imagesBase, null, "privateBetaPage.jade", crossGovGaTrackerId);
         errorHeader = Optional.empty();
         errorMessage = Optional.of("The Identity Assurance Test Service is for testing purposes only, and is only open to invited participants.");
     }

--- a/src/main/java/uk/gov/ida/rp/testrp/views/TestRpSuccessPageView.java
+++ b/src/main/java/uk/gov/ida/rp/testrp/views/TestRpSuccessPageView.java
@@ -21,9 +21,10 @@ public class TestRpSuccessPageView extends TestRpView {
             final Optional<String> errorHeader,
             final Optional<String> errorMessage,
             final Optional<String> rpName,
-            final Optional<LevelOfAssuranceDto> loa) {
+            final Optional<LevelOfAssuranceDto> loa,
+            final String crossGovGaTrackerId) {
 
-        super(javascriptBase, stylesheetsBase, imagesBase, session, "successPage.jade");
+        super(javascriptBase, stylesheetsBase, imagesBase, session, "successPage.jade", crossGovGaTrackerId);
         this.errorHeader = errorHeader;
         this.errorMessage = errorMessage;
         this.rpName = rpName;

--- a/src/main/java/uk/gov/ida/rp/testrp/views/TestRpTokenServiceUnavailablePageView.java
+++ b/src/main/java/uk/gov/ida/rp/testrp/views/TestRpTokenServiceUnavailablePageView.java
@@ -7,8 +7,8 @@ public class TestRpTokenServiceUnavailablePageView extends TestRpView {
     private final Optional<String> errorHeader;
     private final Optional<String> errorMessage;
 
-    public TestRpTokenServiceUnavailablePageView(String javascriptBase, String stylesheetsBase, String imagesBase) {
-        super(javascriptBase, stylesheetsBase, imagesBase, null, "tokenServiceUnavailablePage.jade");
+    public TestRpTokenServiceUnavailablePageView(String javascriptBase, String stylesheetsBase, String imagesBase, String crossGovGaTrackerId) {
+        super(javascriptBase, stylesheetsBase, imagesBase, null, "tokenServiceUnavailablePage.jade", crossGovGaTrackerId);
         errorHeader = Optional.empty();
         errorMessage = Optional.of("We are unable to process your request right now. Please try again soon");
     }

--- a/src/main/java/uk/gov/ida/rp/testrp/views/TestRpUserAccountCreatedView.java
+++ b/src/main/java/uk/gov/ida/rp/testrp/views/TestRpUserAccountCreatedView.java
@@ -12,8 +12,8 @@ public class TestRpUserAccountCreatedView extends TestRpView {
     private final List<String> attributes;
     private final String loa;
 
-    public TestRpUserAccountCreatedView(String javascriptBase, String stylesheetsBase, String imagesBase, Session session, List<String> attributes, String loa) {
-        super(javascriptBase, stylesheetsBase, imagesBase, session, "userAccountCreated.jade");
+    public TestRpUserAccountCreatedView(String javascriptBase, String stylesheetsBase, String imagesBase, Session session, List<String> attributes, String loa, String crossGovGaTrackerId) {
+        super(javascriptBase, stylesheetsBase, imagesBase, session, "userAccountCreated.jade", crossGovGaTrackerId);
         this.attributes = attributes;
         this.loa = loa;
     }

--- a/src/main/java/uk/gov/ida/rp/testrp/views/TestRpView.java
+++ b/src/main/java/uk/gov/ida/rp/testrp/views/TestRpView.java
@@ -15,12 +15,15 @@ public class TestRpView extends View {
     private final URI imagesBase;
     private final boolean isUserAuthenticated;
 
+    private final String crossGovGaTrackerId;
+
     public TestRpView(
             final String javascriptBase,
             final String stylesheetsBase,
             final String imagesBase,
             final Session session,
-            final String templateName) {
+            final String templateName,
+            final String crossGovGaTrackerId) {
 
         super(templateName);
 
@@ -30,6 +33,7 @@ public class TestRpView extends View {
         this.stylesheetsBase = UriBuilder.fromPath(stylesheetsBase).build();
         this.imagesBase = UriBuilder.fromPath(imagesBase).build();
         this.isUserAuthenticated = isUserAuthenticated();
+        this.crossGovGaTrackerId = crossGovGaTrackerId;
     }
 
     public URI getJavascriptBase() {
@@ -51,4 +55,9 @@ public class TestRpView extends View {
     public boolean isUserAuthenticated(){
         return session != null;
     }
+
+    public String getCrossGovGaTrackerId() {
+        return crossGovGaTrackerId;
+    }
+
 }

--- a/src/main/resources/assets/scripts/ga.js
+++ b/src/main/resources/assets/scripts/ga.js
@@ -14,7 +14,4 @@ if (crossGovGaTrackerId) {
     window.ga("govuk_shared.linker.set", "anonymizeIp", true);
     window.ga("govuk_shared.linker:autoLink", domainList, false, true);
     window.ga("govuk_shared.send", "pageview");
-    window.ga(function() {
-        if (window.autoSubmit) window.autoSubmit();
-    });
 }

--- a/src/main/resources/assets/scripts/ga.js
+++ b/src/main/resources/assets/scripts/ga.js
@@ -1,17 +1,20 @@
-var crossGovGaTrackerId = document.getElementById("cross-gov-ga-tracker-id");
-if (crossGovGaTrackerId) {
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+ document.addEventListener('DOMContentLoaded', function(){
+    var crossGovGaTrackerId = document.getElementById("cross-gov-ga-tracker-id");
+    if (crossGovGaTrackerId && crossGovGaTrackerId.innerText) {
+        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+        })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-    var domainList = [
-        "www.gov.uk",
-        "localhost"
-    ];
-    window.ga("create", crossGovGaTrackerId.innerText, "auto", "govuk_shared", {"allowLinker": true});
-    window.ga("govuk_shared.require", "linker");
-    window.ga("govuk_shared.linker.set", "anonymizeIp", true);
-    window.ga("govuk_shared.linker:autoLink", domainList, false, true);
-    window.ga("govuk_shared.send", "pageview");
-}
+        var domainList = [
+            "www.gov.uk",
+            "localhost"
+        ];
+
+        window.ga("create", crossGovGaTrackerId.innerText, "auto", "govuk_shared", {"allowLinker": true});
+        window.ga("govuk_shared.require", "linker");
+        window.ga("govuk_shared.linker.set", "anonymizeIp", true);
+        window.ga("govuk_shared.linker:autoLink", domainList, false, true);
+        window.ga("govuk_shared.send", "pageview");
+    }
+ });

--- a/src/main/resources/assets/scripts/ga.js
+++ b/src/main/resources/assets/scripts/ga.js
@@ -1,0 +1,14 @@
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+var crossGovGaTrackerId = 'UA-XXXXX-Y';
+var domainList = [
+    'www.gov.uk'
+];
+window.ga("create", crossGovGaTrackerId, "auto", "govuk_shared", {"allowLinker": true});
+window.ga("govuk_shared.require", "linker");
+window.ga("govuk_shared.linker.set", "anonymizeIp", true);
+window.ga("govuk_shared.linker:autoLink", domainList, false, true);
+window.ga("govuk_shared.send", "pageview");

--- a/src/main/resources/assets/scripts/ga.js
+++ b/src/main/resources/assets/scripts/ga.js
@@ -1,4 +1,4 @@
-var crossGovGaTrackerId = document.getElementById("cross-gov-ga-tracker-id").innerText;
+var crossGovGaTrackerId = document.getElementById("cross-gov-ga-tracker-id");
 if (crossGovGaTrackerId) {
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
         (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
@@ -9,7 +9,7 @@ if (crossGovGaTrackerId) {
         "www.gov.uk",
         "localhost"
     ];
-    window.ga("create", crossGovGaTrackerId, "auto", "govuk_shared", {"allowLinker": true});
+    window.ga("create", crossGovGaTrackerId.innerText, "auto", "govuk_shared", {"allowLinker": true});
     window.ga("govuk_shared.require", "linker");
     window.ga("govuk_shared.linker.set", "anonymizeIp", true);
     window.ga("govuk_shared.linker:autoLink", domainList, false, true);

--- a/src/main/resources/assets/scripts/ga.js
+++ b/src/main/resources/assets/scripts/ga.js
@@ -1,14 +1,20 @@
-(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+var crossGovGaTrackerId = document.getElementById("cross-gov-ga-tracker-id").innerText;
+if (crossGovGaTrackerId) {
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-var crossGovGaTrackerId = 'UA-XXXXX-Y';
-var domainList = [
-    'www.gov.uk'
-];
-window.ga("create", crossGovGaTrackerId, "auto", "govuk_shared", {"allowLinker": true});
-window.ga("govuk_shared.require", "linker");
-window.ga("govuk_shared.linker.set", "anonymizeIp", true);
-window.ga("govuk_shared.linker:autoLink", domainList, false, true);
-window.ga("govuk_shared.send", "pageview");
+    var domainList = [
+        "www.gov.uk",
+        "localhost"
+    ];
+    window.ga("create", crossGovGaTrackerId, "auto", "govuk_shared", {"allowLinker": true});
+    window.ga("govuk_shared.require", "linker");
+    window.ga("govuk_shared.linker.set", "anonymizeIp", true);
+    window.ga("govuk_shared.linker:autoLink", domainList, false, true);
+    window.ga("govuk_shared.send", "pageview");
+    window.ga(function() {
+        if (window.autoSubmit) window.autoSubmit();
+    });
+}

--- a/src/main/resources/assets/scripts/saml-redirect-auto-submit.js
+++ b/src/main/resources/assets/scripts/saml-redirect-auto-submit.js
@@ -4,4 +4,5 @@ window.setTimeout(function () {
     document.forms[0].removeAttribute("style");
 }, 5000);
 
-document.forms[0].submit();
+var submit = document.getElementById('continue-button');
+if (submit) submit.click();

--- a/src/main/resources/assets/scripts/saml-redirect-auto-submit.js
+++ b/src/main/resources/assets/scripts/saml-redirect-auto-submit.js
@@ -11,4 +11,10 @@ window.autoSubmit = function() {
     if (submit) submit.click();
 };
 
-if (!window.ga) window.autoSubmit();
+if (window.ga) {
+    window.ga(function() {
+        window.autoSubmit();
+    });
+} else {
+    window.autoSubmit();
+}

--- a/src/main/resources/assets/scripts/saml-redirect-auto-submit.js
+++ b/src/main/resources/assets/scripts/saml-redirect-auto-submit.js
@@ -4,5 +4,9 @@ window.setTimeout(function () {
     document.forms[0].removeAttribute("style");
 }, 5000);
 
-var submit = document.getElementById('continue-button');
-if (submit) submit.click();
+window.autoSubmit = function() {
+    var submit = document.getElementById('continue-button');
+    if (submit) submit.click();
+};
+
+if (!window.ga) window.autoSubmit();

--- a/src/main/resources/assets/scripts/saml-redirect-auto-submit.js
+++ b/src/main/resources/assets/scripts/saml-redirect-auto-submit.js
@@ -5,6 +5,8 @@ window.setTimeout(function () {
 }, 5000);
 
 window.autoSubmit = function() {
+    // Using button.click() rather than form.submit() to allow GA to decorate
+    // form action with _ga parameter when required
     var submit = document.getElementById('continue-button');
     if (submit) submit.click();
 };

--- a/src/main/resources/uk/gov/ida/rp/testrp/views/layout/layout.jade
+++ b/src/main/resources/uk/gov/ida/rp/testrp/views/layout/layout.jade
@@ -30,6 +30,7 @@ html(lang="en")
   body(class="#{bodyClass}")
 
     script(src='/assets/scripts/js-enabled.js')
+    script(src='/assets/scripts/ga.js')
 
     #skiplink-container
       div

--- a/src/main/resources/uk/gov/ida/rp/testrp/views/layout/layout.jade
+++ b/src/main/resources/uk/gov/ida/rp/testrp/views/layout/layout.jade
@@ -28,6 +28,8 @@ html(lang="en")
     meta(property="og:image", content="#{imagesBase}/opengraph-image.png")
     block headerScripts
   body(class="#{bodyClass}")
+    span#cross-gov-ga-tracker-id.hidden
+      #{ crossGovGaTrackerId }
 
     script(src='/assets/scripts/js-enabled.js')
     script(src='/assets/scripts/ga.js')

--- a/src/main/resources/uk/gov/ida/rp/testrp/views/samlRedirectView.ftl
+++ b/src/main/resources/uk/gov/ida/rp/testrp/views/samlRedirectView.ftl
@@ -26,6 +26,7 @@
         background-color: #00692f;
       }
     </style>
+    <script type="text/javascript" src="/assets/scripts/ga.js"></script>
 </head>
 <body>
 <form class='verify-saml-form' action="${targetUri}" method="POST">

--- a/src/main/resources/uk/gov/ida/rp/testrp/views/samlRedirectView.ftl
+++ b/src/main/resources/uk/gov/ida/rp/testrp/views/samlRedirectView.ftl
@@ -26,19 +26,21 @@
         background-color: #00692f;
       }
     </style>
-    <script type="text/javascript" src="/assets/scripts/ga.js"></script>
 </head>
 <body>
-<form class='verify-saml-form' action="${targetUri}" method="POST">
-       <h1>Continue to next step</h1>
-       <p>Because Javascript is not enabled on your browser, you must press the continue button</p>
-    <input type="hidden" value="${body}" name="SAMLRequest"/>
-    <input type="hidden" value="${relayState}" name="RelayState"/>
-    <#if showJourneyHint>
-        <input type="hidden" value="${journeyHint}" name="journey_hint"/>
-    </#if>
-    <button class='verify-button' id="continue-button">Continue</button>
-</form>
-<script type="text/javascript" src="/assets/scripts/saml-redirect-auto-submit.js"></script>
+    <span style="display: none;" id="cross-gov-ga-tracker-id">${ crossGovGaTrackerId }</span>
+
+    <form class='verify-saml-form' action="${targetUri}" method="POST">
+        <h1>Continue to next step</h1>
+        <p>Because Javascript is not enabled on your browser, you must press the continue button</p>
+        <input type="hidden" value="${body}" name="SAMLRequest"/>
+        <input type="hidden" value="${relayState}" name="RelayState"/>
+        <#if showJourneyHint>
+            <input type="hidden" value="${journeyHint}" name="journey_hint"/>
+        </#if>
+        <button class='verify-button' id="continue-button">Continue</button>
+    </form>
+    <script type="text/javascript" src="/assets/scripts/ga.js"></script>
+    <script type="text/javascript" src="/assets/scripts/saml-redirect-auto-submit.js"></script>
 </body>
 </html>

--- a/src/test/java/uk/gov/ida/rp/testrp/filters/SecurityHeadersFilterTest.java
+++ b/src/test/java/uk/gov/ida/rp/testrp/filters/SecurityHeadersFilterTest.java
@@ -47,7 +47,7 @@ public class SecurityHeadersFilterTest {
         assertThat(headers.get("X-Content-Type-Options").size()).isEqualTo(1);
         assertThat(headers.containsKey("Content-Security-Policy")).isTrue();
         assertThat(headers.get("Content-Security-Policy").size()).isEqualTo(1);
-        assertThat(headers.get("Content-Security-Policy").get(0)).isEqualTo("default-src 'self'; font-src data:; img-src 'self'; object-src 'none'; style-src 'self' 'unsafe-inline'; script-src 'self';");
+        assertThat(headers.get("Content-Security-Policy").get(0)).isEqualTo("default-src 'self'; font-src data:; img-src 'self' www.google-analytics.com; object-src 'none'; style-src 'self' 'unsafe-inline'; script-src 'self' www.google-analytics.com; connect-src 'self' www.google-analytics.com;");
     }
 
 }

--- a/src/test/java/uk/gov/ida/rp/testrp/resources/AuthnResponseReceiverResourceTest.java
+++ b/src/test/java/uk/gov/ida/rp/testrp/resources/AuthnResponseReceiverResourceTest.java
@@ -47,7 +47,7 @@ public class AuthnResponseReceiverResourceTest {
         when(authnResponseReceiverHandler.handleResponse(eq(samlResponse), any())).thenReturn(responseFromHub);
 
         AuthnResponseReceiverResource resource = new AuthnResponseReceiverResource(authnResponseReceiverHandler, testRpConfiguration);
-        Response response = resource.doLogin(samlResponse, SessionId.createNewSessionId());
+        Response response = resource.doLogin(samlResponse, SessionId.createNewSessionId(), null);
         assertThat(response.getLocation().toString()).isEqualTo("/test-rp?errorCode=NoAuthenticationContext");
     }
 }


### PR DESCRIPTION
## What

Now we've implemented cross-domain tracking on Verify, we should update test-rp to as an example of how to send the `_ga` client ID parameter when its hand the user over to Verify.

## Why

To aid future testing effort and as a working example.

Also, now fixed Javascript error that caused smoke test failures in prod.