### PR TITLE
BAU: Fix the startup script

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -13,10 +13,6 @@ fi
 source ../verify-local-startup/lib/services.sh
 source ../verify-local-startup/config/env.sh
 
-if test ! "$1" == "skip-build"; then
-    ./gradlew clean build copyToLib
-fi
-
-mkdir -p logs
-start_service verify-test-rp . configuration/local/test-rp.yml $TEST_RP_PORT
+build_service ../verify-test-rp
+start_service verify-test-rp ../verify-test-rp configuration/local/test-rp.yml $TEST_RP_PORT
 wait


### PR DESCRIPTION
The startup script failed to start Verify Test RP due to the following error.

`FAILURE: Build failed with an exception.

* What went wrong:
Task 'copyToLib' not found in root project 'verify-test-rp'.`

copyToLib task was not found. This change updates the script to use build_service function to resolve this error.

Author: @adityapahuja