### PR TITLE
Add configuration for MSA backward compatibility testing

### DIFF
--- a/configuration/test-rp.yml
+++ b/configuration/test-rp.yml
@@ -33,7 +33,7 @@ allowInsecureMetadataLocation: true
 
 msaMetadataUri: ${TEST_RP_MSA_METADATA_URL}
 
-msaEntityId: http://www.test-rp-ms.gov.uk/SAML2/MD
+msaEntityId: ${MSA_ENTITY_ID:-http://www.test-rp-ms.gov.uk/SAML2/MD}
 hubEntityId: ${METADATA_ENTITY_ID}
 
 forceAuthentication: false

--- a/configuration/test-rp.yml
+++ b/configuration/test-rp.yml
@@ -17,7 +17,7 @@ dontCacheFreemarkerTemplates: false
 cookieName: test-rp-session
 
 saml:
-  entityId: http://www.%s.gov.uk/SAML2/MD
+  entityId: ${TEST_RP_ENTITY_ID:-http://www.%s.gov.uk/SAML2/MD}
   expectedDestination: ${TEST_RP_URL}
 
 httpClient:

--- a/manifest-for-msa-backcompat.yml.tmpl
+++ b/manifest-for-msa-backcompat.yml.tmpl
@@ -1,0 +1,30 @@
+# test-rp config for supporting msa backwards-compatibility testing in
+# staging
+---
+applications:
+  - name: test-rp-staging-backcompat-${INDEX}
+    routes:
+      - route: test-rp-staging-backcompat-${INDEX}.apps.internal
+      - route: test-rp-staging-backcompat-${INDEX}.cloudapps.digital
+      - route: test-rp-staging-backcompat-${INDEX}.cloudapps.digital/private
+    memory: 1G
+    buildpack: java_buildpack
+    env:
+      JBP_CONFIG_OPEN_JDK_JRE: '{ jre: { version: 11.+ } }'
+      CONFIG_FILE: /app/test-rp/test-rp.yml
+      LOG_PATH: /app/test-rp/logs
+      LOG_LEVEL: INFO
+      TEST_RP_URL: https://test-rp-staging-backcompat-${INDEX}.cloudapps.digital
+      TEST_RP_MSA_METADATA_URL: http://test-rp-msa-staging-backcompat-${INDEX}.apps.internal:8080/matching-service/SAML2/metadata
+      MSA_ENTITY_ID: $MSA_ENTITY_ID
+      METADATA_ENTITY_ID: $METADATA_ENTITY_ID
+      TRUSTSTORE_PATH: /app/test-rp/truststores/$TRUSTSTORE_NAME
+      TRUSTSTORE_PASSWORD: $TRUSTSTORE_PASSWORD
+      PRIVATE_BETA_USER_ACCESS_RESTRICTION_ENABLED: $PRIVATE_BETA
+      SHOULD_SHOW_START_WITH_EIDAS_BUTTON: true
+      ENCRYPTION_KEY: $ENCRYPTION_KEY
+      ENCRYPTION_CERT: $ENCRYPTION_CERT
+      SIGNING_KEY: $SIGNING_KEY
+      SIGNING_CERT: $SIGNING_CERT
+    services:
+      - logit-staging

--- a/manifest-for-msa-backcompat.yml.tmpl
+++ b/manifest-for-msa-backcompat.yml.tmpl
@@ -14,6 +14,7 @@ applications:
       CONFIG_FILE: /app/test-rp/test-rp.yml
       LOG_PATH: /app/test-rp/logs
       LOG_LEVEL: INFO
+      TEST_RP_ENTITY_ID: $TEST_RP_ENTITY_ID
       TEST_RP_URL: https://test-rp-staging-backcompat-${INDEX}.cloudapps.digital
       TEST_RP_MSA_METADATA_URL: http://test-rp-msa-staging-backcompat-${INDEX}.apps.internal:8080/matching-service/SAML2/metadata
       MSA_ENTITY_ID: $MSA_ENTITY_ID


### PR DESCRIPTION
This makes the msaEntityId configurable but defaults it to the normal
value.  We need to configure msaEntityId so we can point at different
MSA instances running different versions of the software.