### PR TITLE
template out TEST_RP_ENTITY_ID in backcompat config

### DIFF
--- a/manifest-for-msa-backcompat.yml.tmpl
+++ b/manifest-for-msa-backcompat.yml.tmpl
@@ -14,10 +14,10 @@ applications:
       CONFIG_FILE: /app/test-rp/test-rp.yml
       LOG_PATH: /app/test-rp/logs
       LOG_LEVEL: INFO
-      TEST_RP_ENTITY_ID: $TEST_RP_ENTITY_ID
+      TEST_RP_ENTITY_ID: http://www.test-rp-${INDEX}.gov.uk/SAML2/MD
       TEST_RP_URL: https://test-rp-staging-backcompat-${INDEX}.cloudapps.digital
       TEST_RP_MSA_METADATA_URL: http://test-rp-msa-staging-backcompat-${INDEX}.apps.internal:8080/matching-service/SAML2/metadata
-      MSA_ENTITY_ID: $MSA_ENTITY_ID
+      MSA_ENTITY_ID: http://www.test-rp-ms-${INDEX}.gov.uk/SAML2/MD
       METADATA_ENTITY_ID: $METADATA_ENTITY_ID
       TRUSTSTORE_PATH: /app/test-rp/truststores/$TRUSTSTORE_NAME
       TRUSTSTORE_PASSWORD: $TRUSTSTORE_PASSWORD


### PR DESCRIPTION
Rather than require our pipeline to template all this stuff out,
generate it all from the ${INDEX} variable.