### PR TITLE
 Add radio button to use the loa2-loa1-test-rp

### DIFF
--- a/src/main/resources/assets/scripts/set-rp-name.js
+++ b/src/main/resources/assets/scripts/set-rp-name.js
@@ -8,6 +8,7 @@ function setRpName(event) {
 }
 
 document.getElementById('loa1-rp').addEventListener('click', setRpName);
+document.getElementById('loa2-loa1-rp').addEventListener('click', setRpName);
 document.getElementById('forceauthn-noc3-rp').addEventListener('click', setRpName);
 document.getElementById('not-signed-by-hub-rp').addEventListener('click', setRpName);
 document.getElementById('non-eidas-rp').addEventListener('click', setRpName);

--- a/src/main/resources/uk/gov/ida/rp/testrp/views/landingPage.jade
+++ b/src/main/resources/uk/gov/ida/rp/testrp/views/landingPage.jade
@@ -42,6 +42,10 @@ block content
         | accepts identities to LOA 1 (by default, this service will test LOA 2 journeys)
 
       p
+        input#loa2-loa1-rp(type="radio", name="rp-name-radio", value="loa2-loa1-test-rp")
+        | prefers LOA 2 identities but will accept LOA 1
+
+      p
         input#forceauthn-noc3-rp(type="radio", name="rp-name-radio", value="test-rp-noc3")
         | uses ForceAuthn and no cycle3
 


### PR DESCRIPTION
- We now have an RP which has LOA2 first in config followed by LOA1. This will change the order in which the LOAs appear in the AuthnRequest so that LOA2 is first in the list. This is to show that the RP prefers LOA2 but will accept LOA1 if a user fails to get LOA2.
- Add a button to the Test RP home page so the user can select to use the loa2-loa1-test-rp.

- This feature will not work until the frontend and hub PRs 