### PR TITLE
HUB-675 Update dockerfile to Java11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:4.7.0-jdk8 as build
+FROM gradle:5.5.1-jdk11 as build
 
 WORKDIR /test-rp
 USER root
@@ -17,7 +17,7 @@ RUN gradle installDist
 ENTRYPOINT ["gradle", "--no-daemon"]
 CMD ["tasks"]
 
-FROM openjdk:8-jre
+FROM openjdk:11-jre
 
 WORKDIR /test-rp
 


### PR DESCRIPTION
Some of the dependancies for TestRP now require Java11.  This updates the docker file to use Java 11 which allows verify-local-startup to build and run TestRP.