### PR TITLE
HUB-795: Allow entity IDs to be configurable in PaaS

### DIFF
--- a/manifest.yml.tmpl
+++ b/manifest.yml.tmpl
@@ -14,6 +14,8 @@ applications:
       LOG_LEVEL: INFO
       TEST_RP_URL: https://test-rp-$ENV.cloudapps.digital
       TEST_RP_MSA_METADATA_URL: http://test-rp-msa-$ENV.apps.internal:8080/matching-service/SAML2/metadata
+      TEST_RP_ENTITY_ID: $TEST_RP_ENTITY_ID
+      MSA_ENTITY_ID: $MSA_ENTITY_ID
       METADATA_ENTITY_ID: $METADATA_ENTITY_ID
       TRUSTSTORE_PATH: /app/test-rp/truststores/$TRUSTSTORE_NAME
       TRUSTSTORE_PASSWORD: $TRUSTSTORE_PASSWORD


### PR DESCRIPTION
This allows entity IDs defined in the pipeline to be passed through to
the PaaS deployment.