### PR TITLE
Update dockerfile to use OpenJDK from Docker Hub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM gradle:6.8.3-jdk11 as build
+ARG registry_image_gradle=gradle:6.7.0-jdk11
+ARG registry_image_jdk=openjdk:11.0.11-jre
+
+FROM ${registry_image_gradle} as build
 
 WORKDIR /test-rp
 USER root
@@ -17,7 +20,7 @@ RUN gradle installDist
 ENTRYPOINT ["gradle", "--no-daemon"]
 CMD ["tasks"]
 
-FROM ghcr.io/alphagov/verify/java:openjdk-11
+FROM ${registry_image_jdk}
 
 WORKDIR /test-rp
 


### PR DESCRIPTION
We moved the majority of images away from GHCR to DockerHub a while ago
it seems that test-rp wasn't shown the same love.  So this PR fixes that
issue and also allows us to inject a docker image name using build args
which is useful for testing and for verify-local-startup.